### PR TITLE
re-support ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache: bundler
 
 matrix:
   include:
+    - rvm: 2.3
     - rvm: 2.4
     - rvm: 2.5
     - rvm: 2.6

--- a/protocol-http.gemspec
+++ b/protocol-http.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 		f.match(%r{^(test|spec|features)/})
 	end
 	
-	spec.required_ruby_version = '>= 2.4.0'
+	spec.required_ruby_version = '>= 2.3.0'
 	
 	spec.require_paths = ["lib"]
 	


### PR DESCRIPTION
Hi. I'm a maintainer of [fluentd](https://github.com/fluent/fluentd). fluend began to use [async-http](https://github.com/socketry/async-http) in this [PR](https://github.com/fluent/fluentd/pull/2447) 

I'd like protocol-http to re-support ruby 2.3 which is the version fluentd supports yet.
I know that MRI teams had ended the support of ruby 2.3. however, ruby 2.3 is still used by many people, and we have to support this version.

If this gem re-support ruby 2.3, it's very helpful for fluentd. 
What do you think of this?  @ioquatix 
