### PR TITLE
Resolve a warning when digest is undefined

### DIFF
--- a/lib/protocol/http/body/buffered.rb
+++ b/lib/protocol/http/body/buffered.rb
@@ -56,6 +56,7 @@ module Protocol
 					@length = length
 					
 					@index = 0
+					@digest = nil
 				end
 				
 				attr :chunks


### PR DESCRIPTION
I noticed this when running a test suite with warnings enabled.