### PR TITLE
Body::Readable#each returns enumerator without a block

### DIFF
--- a/lib/protocol/http/body/readable.rb
+++ b/lib/protocol/http/body/readable.rb
@@ -83,11 +83,15 @@ module Protocol
 				
 				# Enumerate all chunks until finished, then invoke `#close`.
 				def each
-					while chunk = self.read
-						yield chunk
+					return to_enum(:each) unless block_given?
+					
+					begin
+						while chunk = self.read
+							yield chunk
+						end
+					ensure
+						self.close($!)
 					end
-				ensure
-					self.close($!)
 				end
 				
 				# Read all remaining chunks into a single binary string using `#each`.

--- a/spec/protocol/http/body/buffered_spec.rb
+++ b/spec/protocol/http/body/buffered_spec.rb
@@ -127,4 +127,32 @@ RSpec.describe Protocol::HTTP::Body::Buffered do
 			expect(subject.read).to be == "Hello"
 		end
 	end
+	
+	describe "#each" do
+		let(:result) { [] }
+		
+		context "when passed a block" do
+			it "iterates over chunks" do
+				subject.each { |chunk| result << chunk }
+				expect(result).to be == body
+			end
+		end
+		
+		context "without a block" do
+			it "returns an enumerator" do
+				expect(subject.each).to be_a(Enumerator)
+			end
+			
+			it "can be chained with enumerator methods" do
+				subject.each.with_index do |chunk, index|
+					if index.zero?
+						result << chunk.upcase
+					else
+						result << chunk.downcase
+					end
+				end
+				expect(result).to be == ["HELLO", "world"]
+			end
+		end
+	end
 end


### PR DESCRIPTION
This PR adds a feature for `Body::Readable#each`. This method will return `Enumerator` if called without a block.

This is the "real" code I'd be using this feature with (I currently use `each` and manually increment `index`):

```ruby
require "async"
require "async/http/internet"

Async do |task|
  internet = Async::HTTP::Internet.new

  response = internet.get(url)
  response.body.each.with_index(1) do |chunk, index|
    # Don't saturate the CPU
    Async::Task.current.yield if index.modulo(10).zero?

    cpu_heavy_operation(chunk)
  end
end
```

## Types of Changes

- [ ] Bug fix.
- [x] New feature.
- [ ] Performance improvement.

## Testing

- [x] I added new tests for my changes.
- [x] I ran all the tests locally.

Please let me know if you think we need more tests for this.