### PR TITLE
Avoid "shadowing outer local variable - value"

### DIFF
--- a/lib/protocol/http/header/cache_control.rb
+++ b/lib/protocol/http/header/cache_control.rb
@@ -73,7 +73,7 @@ module Protocol
 				end
 				
 				def max_age
-					if value = self.find{|value| value.start_with?(MAX_AGE)}
+					if value = self.find{|v| v.start_with?(MAX_AGE)}
 						_, age = value.split('=', 2)
 						
 						return Integer(age)


### PR DESCRIPTION
## Description

This PR attempts to avoid a Ruby warning, which was emitted when running a test suite for another project. The warning looked like:

    gems/protocol-http-0.22.2/lib/protocol/http/header/cache_control.rb:76: warning: shadowing outer local variable - value


### Types of Changes

- Maintenance.

### Testing


- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
