### PR TITLE
Allow trailers without explicit `trailer` header.

### DIFF
--- a/lib/protocol/http/headers.rb
+++ b/lib/protocol/http/headers.rb
@@ -108,8 +108,6 @@ module Protocol
 			
 			# Record the current headers, and prepare to receive trailer.
 			def trailer!(&block)
-				return nil unless self.include?(TRAILER)
-				
 				@tail ||= @fields.size
 				
 				return to_enum(:trailer!) unless block_given?

--- a/spec/protocol/http/headers_spec.rb
+++ b/spec/protocol/http/headers_spec.rb
@@ -179,6 +179,14 @@ RSpec.describe Protocol::HTTP::Headers do
 			
 			expect(trailer.to_h).to be == {'etag' => 'abcd'}
 		end
+		
+		it "can add trailer without explicit header" do
+			trailer = subject.trailer!
+			
+			subject.add('etag', 'abcd')
+			
+			expect(trailer.to_h).to be == {'etag' => 'abcd'}
+		end
 	end
 	
 	describe '#trailer' do


### PR DESCRIPTION
https://github.com/socketry/async-http/pull/92

Based on the discussion and research, `trailer` header is not explicit requirement of sending or receiving trailers, so we should relax this requirement. There is a slight performance cost since now an enumerator would be returned every time, but maybe we can reduce that cost a little bit with an enhanced interface later on.

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
