### PR TITLE
Don't try to call close with current exception on IO/stream instance.

### DIFF
--- a/lib/protocol/http/body/readable.rb
+++ b/lib/protocol/http/body/readable.rb
@@ -72,7 +72,7 @@ module Protocol
 						stream.write(chunk)
 					end
 				ensure
-					stream.close($!)
+					stream.close
 				end
 				
 				# Read all remaining chunks into a buffered body and close the underlying input.


### PR DESCRIPTION
Hopefully fix https://github.com/socketry/protocol-http/issues/13 without introducing other issues.