### PR TITLE
Rename `path` -> `target` to better match RFCs.

### DIFF
--- a/lib/protocol/http/request.rb
+++ b/lib/protocol/http/request.rb
@@ -28,11 +28,11 @@ module Protocol
 		class Request
 			prepend Body::Reader
 			
-			def initialize(scheme = nil, authority = nil, method = nil, path = nil, version = nil, headers = Headers.new, body = nil, protocol = nil)
+			def initialize(scheme = nil, authority = nil, method = nil, target = nil, version = nil, headers = Headers.new, body = nil, protocol = nil)
 				@scheme = scheme
 				@authority = authority
 				@method = method
-				@path = path
+				@target = target
 				@version = version
 				@headers = headers
 				@body = body
@@ -42,11 +42,15 @@ module Protocol
 			attr_accessor :scheme
 			attr_accessor :authority
 			attr_accessor :method
-			attr_accessor :path
+			attr_accessor :target
 			attr_accessor :version
 			attr_accessor :headers
 			attr_accessor :body
 			attr_accessor :protocol
+			
+			def path
+				self.target
+			end
 			
 			# Send the request to the given connection.
 			def call(connection)
@@ -73,7 +77,7 @@ module Protocol
 			end
 			
 			def to_s
-				"#{@scheme}://#{@authority}: #{@method} #{@path} #{@version}"
+				"#{@scheme}://#{@authority}: #{@method} #{@target} #{@version}"
 			end
 		end
 	end

--- a/lib/protocol/http/request.rb
+++ b/lib/protocol/http/request.rb
@@ -48,8 +48,14 @@ module Protocol
 			attr_accessor :body
 			attr_accessor :protocol
 			
+			# Get the request target. For compatibility.
 			def path
 				self.target
+			end
+
+			# Set the request target to a path. For compatibility.
+			def path= value
+				self.target = value
 			end
 			
 			# Send the request to the given connection.


### PR DESCRIPTION
An HTTP request isn't always generated with a path, and in RFCs it's described as `request-target`: https://www.rfc-editor.org/rfc/rfc7230.html#section-3.1.1

This change aligns our attribute naming more closely with the specifications.

### Types of Changes

- Breaking change.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
