### PR TITLE
Improve argument handling.

### DIFF
--- a/lib/protocol/http/middleware/builder.rb
+++ b/lib/protocol/http/middleware/builder.rb
@@ -40,8 +40,8 @@ module Protocol
 					@app = default_app
 				end
 				
-				def use(middleware, *arguments, &block)
-					@use << proc {|app| middleware.new(app, *arguments, &block)}
+				def use(middleware, *arguments, **options, &block)
+					@use << proc {|app| middleware.new(app, *arguments, **options, &block)}
 				end
 				
 				ruby2_keywords(:use) if respond_to?(:ruby2_keywords, true)


### PR DESCRIPTION
When Ruby 2.x is EOL, I believe we should drop `ruby2_keywords` and adopt this PR.

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
