### PR TITLE
Remove `Response#protocol` as it's not a required semantic.

### DIFF
--- a/lib/protocol/http/response.rb
+++ b/lib/protocol/http/response.rb
@@ -28,19 +28,17 @@ module Protocol
 		class Response
 			prepend Body::Reader
 			
-			def initialize(version = nil, status = 200, headers = Headers.new, body = nil, protocol = nil)
+			def initialize(version = nil, status = 200, headers = Headers.new, body = nil)
 				@version = version
 				@status = status
 				@headers = headers
 				@body = body
-				@protocol = protocol
 			end
 			
 			attr_accessor :version
 			attr_accessor :status
 			attr_accessor :headers
 			attr_accessor :body
-			attr_accessor :protocol
 			
 			def hijack?
 				false
@@ -82,11 +80,11 @@ module Protocol
 				@status == 500
 			end
 			
-			def self.[](status, headers = nil, body = nil, protocol = nil)
+			def self.[](status, headers = nil, body = nil)
 				body = Body::Buffered.wrap(body)
 				headers = ::Protocol::HTTP::Headers[headers]
 				
-				self.new(nil, status, headers, body, protocol)
+				self.new(nil, status, headers, body)
 			end
 			
 			def self.for_exception(exception)

--- a/spec/protocol/http/response_spec.rb
+++ b/spec/protocol/http/response_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe Protocol::HTTP::Response do
 			status: 200,
 			headers: headers,
 			body: body,
-			protocol: nil
 		)}
 		
 		it {is_expected.to_not be_hijack}


### PR DESCRIPTION
At one point, it appears I believed this was necessary, but I believe it's not part of any of the published semantics, so let's try to remove it.

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
