### PR TITLE
Fix cookie key-value parsing

### DIFF
--- a/lib/protocol/http/cookie.rb
+++ b/lib/protocol/http/cookie.rb
@@ -68,7 +68,7 @@ module Protocol
 			def self.parse(string)
 				head, *directives = string.split(/\s*;\s*/)
 				
-				key, value = head.split('=')
+				key, value = head.split('=', 2)
 				directives = self.parse_directives(directives)
 				
 				self.new(

--- a/spec/protocol/http/header/cookie_spec.rb
+++ b/spec/protocol/http/header/cookie_spec.rb
@@ -36,4 +36,15 @@ RSpec.describe Protocol::HTTP::Header::Cookie do
 			expect(session.directives).to include('secure')
 		end
 	end
+
+	context "session=123==; secure" do
+		it "has named cookie" do
+			expect(cookies).to include('session')
+
+			session = cookies['session']
+			expect(session).to have_attributes(name: 'session')
+			expect(session).to have_attributes(value: '123==')
+			expect(session.directives).to include('secure')
+		end
+	end
 end


### PR DESCRIPTION
When I was using `Async::HTTP::Internet`, I received headers back that removed important equal signs. Here's an example of something that I did:
```ruby
async_task = Async do
  internet = Async::HTTP::Internet.new(protocol: Async::HTTP::Protocol::HTTPS)
  endpoint = "https://some_random_website.here" # replace website here
  headers = []
  body = {}
  response = internet.post(endpoint, headers, body)
  response.headers["set-cookie"]&.to_h&.transform_values(&:value)
end
async_task.wait
```
This caused problems because headers like`["Set-Cookie", "t=some_random_string==; path=/cometd/; HttpOnly"]` would get converted to `{t => some_random_string}` rather than `{t=>some_random_string==}`

Eventually, we were able to pinpoint this to `.value` from `Cookie`, specifically in`self.parse`.

### Types of Changes

- Bug fix.

### Testing

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
