### PR TITLE
Use double splat to pass opts to File.open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /doc/
 /pkg/
 /spec/reports/
+/spec/protocol/http/body/reader_spec.txt
 /tmp/
 /external/
 

--- a/lib/protocol/http/body/reader.rb
+++ b/lib/protocol/http/body/reader.rb
@@ -57,9 +57,9 @@ module Protocol
 				end
 				
 				# Write the body of the response to the given file path.
-				def save(path, mode = ::File::WRONLY|::File::CREAT, *args)
+				def save(path, mode = ::File::WRONLY|::File::CREAT, **options)
 					if @body
-						::File.open(path, mode, *args) do |file|
+						::File.open(path, mode, **options) do |file|
 							self.each do |chunk|
 								file.write(chunk)
 							end

--- a/spec/protocol/http/body/reader_spec.rb
+++ b/spec/protocol/http/body/reader_spec.rb
@@ -1,0 +1,37 @@
+require 'protocol/http/body/reader'
+
+RSpec.describe Protocol::HTTP::Body::Reader do
+	class TestReader
+		include Protocol::HTTP::Body::Reader
+
+		def initialize(body)
+			@body = body
+		end
+	end
+
+	subject do
+		TestReader.new(%w(the quick brown fox))
+	end
+
+	describe '#save' do
+		let(:path) { File.expand_path('reader_spec.txt', __dir__) }
+
+		before do
+			File.open(path, 'w') {}
+		end
+
+		it 'saves to the provided filename' do
+			expect { subject.save(path) }
+				.to change { File.read(path) }
+				.from('')
+				.to('thequickbrownfox')
+		end
+
+		it 'mirrors the interface of File.open' do
+			expect { subject.save(path, nil, mode: 'w') }
+				.to change { File.read(path) }
+				.from('')
+				.to('thequickbrownfox')
+		end
+	end
+end


### PR DESCRIPTION
Single splat was used previously, making it impossible to pass keyword args to `File.open` through `Reader#save`.

<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
-->

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.

I didn't see tests explicitly covering this feature, and I'm open to adding some,
but file I/O isn't always appreciated in test suites, so I'll defer to your preference
on testing style.

EDIT: added unit tests