### PR TITLE
Check if the input is closed before raise IOError

### DIFF
--- a/lib/protocol/http/body/stream.rb
+++ b/lib/protocol/http/body/stream.rb
@@ -19,6 +19,7 @@ module Protocol
 					# Will hold remaining data in `#read`.
 					@buffer = nil
 					@closed = false
+					@closed_read = false
 				end
 				
 				attr :input
@@ -146,6 +147,7 @@ module Protocol
 				end
 				
 				def close_read
+					@closed_read = true
 					@input&.close
 					@input = nil
 				end
@@ -181,8 +183,7 @@ module Protocol
 				def read_next
 					if @input
 						return @input.read
-					else
-						@input = nil
+					elsif @closed_read
 						raise IOError, "Stream is not readable, input has been closed!"
 					end
 				end


### PR DESCRIPTION
In the `Protocol::HTTP::Body::Stream#read_next`, check if the `@input` is closed.
To distinguish `@input` is empty or closed, `nil` is not enough.
So I added `@closed_read` instance variable to store the state.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
