### PR TITLE
Remove `< Methods` from `Middleware`.

### DIFF
--- a/lib/protocol/http/methods.rb
+++ b/lib/protocol/http/methods.rb
@@ -5,19 +5,34 @@
 
 module Protocol
 	module HTTP
-		# All supported HTTP methods
+		# All supported HTTP methods, as outlined by <https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods>.
 		class Methods
+			# The GET method requests a representation of the specified resource. Requests using GET should only retrieve data.
 			GET = 'GET'
-			POST = 'POST'
-			PUT = 'PUT'
-			PATCH = 'PATCH'
-			DELETE = 'DELETE'
+			
+			# The HEAD method asks for a response identical to a GET request, but without the response body.
 			HEAD = 'HEAD'
-			OPTIONS = 'OPTIONS'
-			LINK = 'LINK'
-			UNLINK = 'UNLINK'
-			TRACE = 'TRACE'
+			
+			# The POST method submits an entity to the specified resource, often causing a change in state or side effects on the server.
+			POST = 'POST'
+			
+			# The PUT method replaces all current representations of the target resource with the request payload.
+			PUT = 'PUT'
+			
+			# The DELETE method deletes the specified resource.
+			DELETE = 'DELETE'
+			
+			# The CONNECT method establishes a tunnel to the server identified by the target resource.
 			CONNECT = 'CONNECT'
+			
+			# The OPTIONS method describes the communication options for the target resource.
+			OPTIONS = 'OPTIONS'
+			
+			# The TRACE method performs a message loop-back test along the path to the target resource.
+			TRACE = 'TRACE'
+			
+			# The PATCH method applies partial modifications to a resource.
+			PATCH = 'PATCH'
 			
 			def self.valid?(name)
 				const_defined?(name)
@@ -26,13 +41,18 @@ module Protocol
 				return false
 			end
 			
+			# Enumerate all HTTP methods.
+			# @yields {|name, value| ...}
+			# 	@parameter name [Symbol] The name of the method, e.g. `:GET`.
+			# 	@parameter value [String] The value of the method, e.g. `"GET"`.
 			def self.each
+				return to_enum(:each) unless block_given?
+				
 				constants.each do |name|
 					yield name, const_get(name)
 				end
 			end
 			
-			# Use Methods.constants to get all constants.
 			self.each do |name, value|
 				define_method(name.downcase) do |location, headers = nil, body = nil|
 					self.call(

--- a/lib/protocol/http/methods.rb
+++ b/lib/protocol/http/methods.rb
@@ -5,7 +5,23 @@
 
 module Protocol
 	module HTTP
-		# All supported HTTP methods, as outlined by <https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods>.
+		# Provides a convenient interface for commonly supported HTTP methods.
+		#
+		# | Method Name | Request Body | Response Body | Safe | Idempotent | Cacheable |
+		# | ----------- | ------------ | ------------- | ---- | ---------- | --------- |
+		# | GET         | Optional     | Yes           | Yes  | Yes        | Yes       |
+		# | HEAD        | Optional     | No            | Yes  | Yes        | Yes       |
+		# | POST        | Yes          | Yes           | No   | No         | Yes       |
+		# | PUT         | Yes          | Yes           | No   | Yes        | No        |
+		# | DELETE      | Optional     | Yes           | No   | Yes        | No        |
+		# | CONNECT     | Optional     | Yes           | No   | No         | No        |
+		# | OPTIONS     | Optional     | Yes           | Yes  | Yes        | No        |
+		# | TRACE       | No           | Yes           | Yes  | Yes        | No        |
+		# | PATCH       | Yes          | Yes           | No   | No         | No        |
+		#
+		# These methods are defined in this module using lower case names. They are for convenience only and you should not overload those methods.
+		#
+		# See <https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods> for more details.
 		class Methods
 			# The GET method requests a representation of the specified resource. Requests using GET should only retrieve data.
 			GET = 'GET'

--- a/lib/protocol/http/middleware.rb
+++ b/lib/protocol/http/middleware.rb
@@ -10,6 +10,16 @@ require_relative 'response'
 
 module Protocol
 	module HTTP
+		# The middleware interface provides a convenient wrapper for implementing HTTP middleware.
+		#
+		# A middleware instance generally needs to respond to two methods:
+		#
+		# - `call(request)` -> `response`
+		# - `close()`
+		#
+		# The call method is called for each request. The close method is called when the server is shutting down.
+		#
+		# You do not need to use the Middleware class to implement middleware. You can implement the interface directly.
 		class Middleware < Methods
 			# Convert a block to a middleware delegate.
 			def self.for(&block)

--- a/lib/protocol/http/middleware.rb
+++ b/lib/protocol/http/middleware.rb
@@ -10,7 +10,7 @@ require_relative 'response'
 
 module Protocol
 	module HTTP
-		class Middleware
+		class Middleware < Methods
 			# Convert a block to a middleware delegate.
 			def self.for(&block)
 				def block.close

--- a/lib/protocol/http/middleware.rb
+++ b/lib/protocol/http/middleware.rb
@@ -20,7 +20,7 @@ module Protocol
 		# The call method is called for each request. The close method is called when the server is shutting down.
 		#
 		# You do not need to use the Middleware class to implement middleware. You can implement the interface directly.
-		class Middleware < Methods
+		class Middleware
 			# Convert a block to a middleware delegate.
 			def self.for(&block)
 				def block.close

--- a/lib/protocol/http/middleware.rb
+++ b/lib/protocol/http/middleware.rb
@@ -10,7 +10,7 @@ require_relative 'response'
 
 module Protocol
 	module HTTP
-		class Middleware < Methods
+		class Middleware
 			# Convert a block to a middleware delegate.
 			def self.for(&block)
 				def block.close

--- a/lib/protocol/http/middleware.rb
+++ b/lib/protocol/http/middleware.rb
@@ -20,7 +20,7 @@ module Protocol
 		# The call method is called for each request. The close method is called when the server is shutting down.
 		#
 		# You do not need to use the Middleware class to implement middleware. You can implement the interface directly.
-		class Middleware
+		class Middleware < Methods
 			# Convert a block to a middleware delegate.
 			def self.for(&block)
 				def block.close

--- a/test/protocol/http/content_encoding.rb
+++ b/test/protocol/http/content_encoding.rb
@@ -12,7 +12,7 @@ describe Protocol::HTTP::ContentEncoding do
 		let(:accept_encoding) {Protocol::HTTP::AcceptEncoding.new(middleware)}
 		
 		it "can request resource without compression" do
-			response = middleware.call(Protocol::HTTP::Request["GET", "/index"])
+			response = middleware.get("/index")
 			
 			expect(response).to be(:success?)
 			expect(response.headers).not.to have_keys('content-encoding')
@@ -22,7 +22,7 @@ describe Protocol::HTTP::ContentEncoding do
 		end
 		
 		it "can request a resource with the identity encoding" do
-			response = accept_encoding.call(Protocol::HTTP::Request["GET", "/index", {'accept-encoding' => 'identity'}])
+			response = accept_encoding.get("/index", {'accept-encoding' => 'identity'})
 			
 			expect(response).to be(:success?)
 			expect(response.headers).not.to have_keys('content-encoding')
@@ -32,7 +32,7 @@ describe Protocol::HTTP::ContentEncoding do
 		end
 		
 		it "can request resource with compression" do
-			response = accept_encoding.call(Protocol::HTTP::Request["GET", "/index", {'accept-encoding' => 'gzip'}])
+			response = accept_encoding.get("/index", {'accept-encoding' => 'gzip'})
 			expect(response).to be(:success?)
 			
 			expect(response.headers['vary']).to be(:include?, 'accept-encoding')
@@ -52,7 +52,7 @@ describe Protocol::HTTP::ContentEncoding do
 		let(:client) {subject.new(app)}
 		
 		it "can request resource with compression" do
-			response = client.call(Protocol::HTTP::Request["GET", "/index", {'accept-encoding' => 'gzip'}])
+			response = client.get("/index", {'accept-encoding' => 'gzip'})
 			expect(response).to be(:success?)
 			
 			expect(response.headers).not.to have_keys('content-encoding')
@@ -70,7 +70,7 @@ describe Protocol::HTTP::ContentEncoding do
 		let(:client) {subject.new(app)}
 		
 		it "does not compress response" do
-			response = client.call(Protocol::HTTP::Request["GET", "/index", {'accept-encoding' => 'gzip'}])
+			response = client.get("/index", {'accept-encoding' => 'gzip'})
 			
 			expect(response).to be(:success?)
 			expect(response.headers).to have_keys('content-encoding')

--- a/test/protocol/http/content_encoding.rb
+++ b/test/protocol/http/content_encoding.rb
@@ -12,7 +12,7 @@ describe Protocol::HTTP::ContentEncoding do
 		let(:accept_encoding) {Protocol::HTTP::AcceptEncoding.new(middleware)}
 		
 		it "can request resource without compression" do
-			response = middleware.get("/index")
+			response = middleware.call(Protocol::HTTP::Request["GET", "/index"])
 			
 			expect(response).to be(:success?)
 			expect(response.headers).not.to have_keys('content-encoding')
@@ -22,7 +22,7 @@ describe Protocol::HTTP::ContentEncoding do
 		end
 		
 		it "can request a resource with the identity encoding" do
-			response = accept_encoding.get("/index", {'accept-encoding' => 'identity'})
+			response = accept_encoding.call(Protocol::HTTP::Request["GET", "/index", {'accept-encoding' => 'identity'}])
 			
 			expect(response).to be(:success?)
 			expect(response.headers).not.to have_keys('content-encoding')
@@ -32,7 +32,7 @@ describe Protocol::HTTP::ContentEncoding do
 		end
 		
 		it "can request resource with compression" do
-			response = accept_encoding.get("/index", {'accept-encoding' => 'gzip'})
+			response = accept_encoding.call(Protocol::HTTP::Request["GET", "/index", {'accept-encoding' => 'gzip'}])
 			expect(response).to be(:success?)
 			
 			expect(response.headers['vary']).to be(:include?, 'accept-encoding')
@@ -52,7 +52,7 @@ describe Protocol::HTTP::ContentEncoding do
 		let(:client) {subject.new(app)}
 		
 		it "can request resource with compression" do
-			response = client.get("/index", {'accept-encoding' => 'gzip'})
+			response = client.call(Protocol::HTTP::Request["GET", "/index", {'accept-encoding' => 'gzip'}])
 			expect(response).to be(:success?)
 			
 			expect(response.headers).not.to have_keys('content-encoding')
@@ -70,7 +70,7 @@ describe Protocol::HTTP::ContentEncoding do
 		let(:client) {subject.new(app)}
 		
 		it "does not compress response" do
-			response = client.get("/index", {'accept-encoding' => 'gzip'})
+			response = client.call(Protocol::HTTP::Request["GET", "/index", {'accept-encoding' => 'gzip'}])
 			
 			expect(response).to be(:success?)
 			expect(response.headers).to have_keys('content-encoding')

--- a/test/protocol/http/methods.rb
+++ b/test/protocol/http/methods.rb
@@ -31,13 +31,11 @@ describe Protocol::HTTP::Methods do
 	it_behaves_like ValidMethod, "DELETE"
 	it_behaves_like ValidMethod, "HEAD"
 	it_behaves_like ValidMethod, "OPTIONS"
-	it_behaves_like ValidMethod, "LINK"
-	it_behaves_like ValidMethod, "UNLINK"
 	it_behaves_like ValidMethod, "TRACE"
 	it_behaves_like ValidMethod, "CONNECT"
 	
-	it "defines exactly 11 methods" do
-		expect(subject.constants.length).to be == 11
+	it "defines exactly 9 methods" do
+		expect(subject.constants.length).to be == 9
 	end
 	
 	with '.valid?' do


### PR DESCRIPTION
An answer to <https://github.com/socketry/protocol-http/issues/26>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.
- Breaking change.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
