### PR TITLE
Prefer 'close' over 'keep-alive' when both are present

### DIFF
--- a/lib/protocol/http/header/connection.rb
+++ b/lib/protocol/http/header/connection.rb
@@ -22,7 +22,7 @@ module Protocol
 				end
 				
 				def keep_alive?
-					self.include?(KEEP_ALIVE)
+					self.include?(KEEP_ALIVE) && !close?
 				end
 				
 				def close?

--- a/test/protocol/http/header/connection.rb
+++ b/test/protocol/http/header/connection.rb
@@ -29,6 +29,13 @@ describe Protocol::HTTP::Header::Connection do
 		end
 	end
 	
+	with "close, keep-alive" do
+		it "should prioritize close over keep-alive" do
+			expect(header).to be(:close?)
+			expect(header).not.to be(:keep_alive?)
+		end
+	end
+	
 	with "upgrade" do
 		it "should indiciate connection can be upgraded" do
 			expect(header).to be(:upgrade?)


### PR DESCRIPTION
If the `Connection` header has both `close` and `keep-alive`, both related methods return true despite the conflicting instructions.

This PR changes `keep_alive?` to return false if `close` is simultaneously present.

Related to socketry/async-http#132

## Types of Changes

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
