### PR TITLE
Introduce explicit support for informational responses.

### DIFF
--- a/lib/protocol/http/response.rb
+++ b/lib/protocol/http/response.rb
@@ -29,51 +29,63 @@ module Protocol
 				false
 			end
 			
+			# Whether the status is 100 (continue).
 			def continue?
 				@status == 100
 			end
 			
+			# Whether the status is considered informational.
 			def informational?
 				@status and @status >= 100 && @status < 200
 			end
 			
+			# Whether the status is considered final. Note that 101 is considered final.
 			def final?
 				# 101 is effectively a final status.
 				@status and @status >= 200 || @status == 101
 			end
 			
+			# Whether the status is 200 (ok).
 			def ok?
 				@status == 200
 			end
 			
+			# Whether the status is considered successful.
 			def success?
 				@status and @status >= 200 && @status < 300
 			end
 			
+			# Whether the status is 206 (partial content).
 			def partial?
 				@status == 206
 			end
 			
+			# Whether the status is considered a redirection.
 			def redirection?
 				@status and @status >= 300 && @status < 400
 			end
 			
+			# Whether the status is 304 (not modified).
 			def not_modified?
 				@status == 304
 			end
 			
+			# Whether the status is 307 (temporary redirect) and should preserve the method of the request when following the redirect.
 			def preserve_method?
 				@status == 307 || @status == 308
 			end
 			
+			# Whether the status is considered a failure.
 			def failure?
 				@status and @status >= 400 && @status < 600
 			end
 			
+			# Whether the status is 400 (bad request).
 			def bad_request?
 				@status == 400
 			end
 			
+			# Whether the status is 500 (internal server error).
 			def internal_server_error?
 				@status == 500
 			end

--- a/lib/protocol/http/response.rb
+++ b/lib/protocol/http/response.rb
@@ -33,6 +33,15 @@ module Protocol
 				@status == 100
 			end
 			
+			def informational?
+				@status and @status >= 100 && @status < 200
+			end
+			
+			def final?
+				# 101 is effectively a final status.
+				@status and @status >= 200 || @status == 101
+			end
+			
 			def ok?
 				@status == 200
 			end

--- a/test/protocol/http/response.rb
+++ b/test/protocol/http/response.rb
@@ -10,9 +10,23 @@ describe Protocol::HTTP::Response do
 	let(:headers) {Protocol::HTTP::Headers.new}
 	let(:body) {nil}
 	
+	InformationalResponse = Sus::Shared("informational response") do
+		it "should be informational" do
+			expect(response).to be(:informational?)
+		end
+		
+		it "should not be a failure" do
+			expect(response).not.to be(:failure?)
+		end
+	end
+	
 	SuccessfulResponse = Sus::Shared("successful response") do
 		it "should be successful" do
 			expect(response).to be(:success?)
+		end
+		
+		it "should not be informational" do
+			expect(response).not.to be(:informational?)
 		end
 		
 		it "should not be a failure" do
@@ -25,6 +39,10 @@ describe Protocol::HTTP::Response do
 			expect(response).to be(:redirection?)
 		end
 		
+		it "should not be informational" do
+			expect(response).not.to be(:informational?)
+		end
+		
 		it "should not be a failure" do
 			expect(response).not.to be(:failure?)
 		end
@@ -33,6 +51,10 @@ describe Protocol::HTTP::Response do
 	FailureResponse = Sus::Shared("failure response") do
 		it "should not be successful" do
 			expect(response).not.to be(:success?)
+		end
+		
+		it "should not be informational" do
+			expect(response).not.to be(:informational?)
 		end
 		
 		it "should be a failure" do
@@ -51,7 +73,38 @@ describe Protocol::HTTP::Response do
 			expect(response).not.to be(:preserve_method?)
 		end
 	end
-			
+	
+	with "100 Continue" do
+		let(:response) {subject.new("HTTP/1.1", 100, headers)}
+		
+		it "should have attributes" do
+			expect(response).to have_attributes(
+				version: be == "HTTP/1.1",
+				status: be == 100,
+				headers: be == headers,
+				body: be == nil,
+				protocol: be == nil
+			)
+		end
+		
+		it_behaves_like InformationalResponse
+		
+		it "should be a continue" do
+			expect(response).to be(:continue?)
+		end
+		
+		it "should not be a failure" do
+			expect(response).not.to be(:failure?)
+		end
+		
+		it "should have a String representation" do
+			expect(response.to_s).to be == "100 HTTP/1.1"
+		end
+		
+		it "should have an Array representation" do
+			expect(response.to_ary).to be == [100, headers, nil]
+		end
+	end
 	
 	with "301 Moved Permanently" do
 		let(:response) {subject.new("HTTP/1.1", 301, headers, body)}

--- a/test/protocol/http/response.rb
+++ b/test/protocol/http/response.rb
@@ -93,10 +93,6 @@ describe Protocol::HTTP::Response do
 			expect(response).to be(:continue?)
 		end
 		
-		it "should not be a failure" do
-			expect(response).not.to be(:failure?)
-		end
-		
 		it "should have a String representation" do
 			expect(response.to_s).to be == "100 HTTP/1.1"
 		end

--- a/test/protocol/http/response.rb
+++ b/test/protocol/http/response.rb
@@ -25,6 +25,10 @@ describe Protocol::HTTP::Response do
 			expect(response).to be(:success?)
 		end
 		
+		it "should be final" do
+			expect(response).to be(:final?)
+		end
+		
 		it "should not be informational" do
 			expect(response).not.to be(:informational?)
 		end
@@ -35,6 +39,10 @@ describe Protocol::HTTP::Response do
 	end
 	
 	RedirectionResponse = Sus::Shared("redirection response") do
+		it "should be final" do
+			expect(response).to be(:final?)
+		end
+		
 		it "should be a redirection" do
 			expect(response).to be(:redirection?)
 		end
@@ -51,6 +59,10 @@ describe Protocol::HTTP::Response do
 	FailureResponse = Sus::Shared("failure response") do
 		it "should not be successful" do
 			expect(response).not.to be(:success?)
+		end
+		
+		it "should be final" do
+			expect(response).to be(:final?)
 		end
 		
 		it "should not be informational" do


### PR DESCRIPTION
The first step to support handling informational responses correctly is to expose the abstract model.

I'm not convinced `101 Switching Protocols` is a non-final response in practice. Because there is no subsequent "final response".

This would be used in `Async::HTTP` like so:

![image](https://github.com/socketry/protocol-http/assets/30030/bc0ac045-1033-401b-a160-6436adb14f75)

More discussion here: https://github.com/socketry/async-http/discussions/134

cc @zarqman wdyt?

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
