### PR TITLE
Query HTTP headers in a case-sensitive manner

### DIFF
--- a/lib/protocol/http/headers.rb
+++ b/lib/protocol/http/headers.rb
@@ -287,7 +287,7 @@ module Protocol
 			end
 			
 			def [] key
-				to_h[key]
+				to_h[key.downcase]
 			end
 			
 			# A hash table of `{key, policy[key].map(values)}`

--- a/test/protocol/http/headers.rb
+++ b/test/protocol/http/headers.rb
@@ -153,6 +153,10 @@ describe Protocol::HTTP::Headers do
 		it 'can lookup fields' do
 			expect(headers['content-type']).to be == 'text/html'
 		end
+
+		it 'can lookup case-insensitive fields' do
+			expect(headers['Content-Type']).to be == 'text/html'
+		end
 	end
 	
 	with '#[]=' do


### PR DESCRIPTION
protocol-http headers are not isometric. When making a request using protocol-http to construct the request, the header keys that are used to construct the request headers cannot be used to retrieve the header values.

Simple demonstration
```
content_type_header = 'Content-Type'
content_type_value = 'application/json'
hash_headers = { content_type_header => content_type_value }
protocol_headers = Protocol::HTTP::Headers[hash_headers]
raise if protocol_headers[content_type_header] != content_type_value
```

This impacts several use cases:
1. Using adapter-agnostic code in a library like Faraday
2. A tightly coupled client-server implementation in HTTP/1.1
3. Echoing headers from the request into the response in HTTP/1.1

The implementation of headers makes incorrect assumptions that only consider HTTP/2, where headers are serialized in the request in their downcased versions.
* In HTTP/1.1, it is incorrect to optimistically downcase every header when being serialized into the request body
* In HTTP/1.1, it is incorrect to provide **case-sensitive** access to the [response headers](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.1-3).

## Types of Changes

- Bug fix.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
