### PR TITLE
Drop `base64` gem dependency

### DIFF
--- a/lib/protocol/http/header/authorization.rb
+++ b/lib/protocol/http/header/authorization.rb
@@ -3,8 +3,6 @@
 # Released under the MIT License.
 # Copyright, 2019-2023, by Samuel Williams.
 
-require 'base64'
-
 module Protocol
 	module HTTP
 		module Header
@@ -21,10 +19,10 @@ module Protocol
 				end
 				
 				def self.basic(username, password)
-					encoded = "#{username}:#{password}"
+					strict_base64_encoded = ["#{username}:#{password}"].pack('m0')
 					
 					self.new(
-						"Basic #{Base64.strict_encode64(encoded)}"
+						"Basic #{strict_base64_encoded}"
 					)
 				end
 			end

--- a/protocol-http.gemspec
+++ b/protocol-http.gemspec
@@ -22,6 +22,4 @@ Gem::Specification.new do |spec|
 	spec.files = Dir.glob(['{lib}/**/*', '*.md'], File::FNM_DOTMATCH, base: __dir__)
 	
 	spec.required_ruby_version = ">= 3.0"
-	
-	spec.add_dependency "base64"
 end


### PR DESCRIPTION
https://github.com/socketry/protocol-http/commit/59d7cabf3512f99250160395e6e8d31de92741b1 added `base64` as a dependency. This instead inlines that call and removes the dependency.

See also:
* https://github.com/rack/rack/pull/2110
* https://github.com/rubocop/rubocop/pull/12313
* https://github.com/elastic/elasticsearch-ruby/pull/2295
* https://github.com/petergoldstein/dalli/pull/986
* etc.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
