### PR TITLE
Use `@callback` to track the state of the invocation.

### DIFF
--- a/lib/protocol/http/body/completable.rb
+++ b/lib/protocol/http/body/completable.rb
@@ -25,24 +25,20 @@ module Protocol
 				end
 				
 				def finish
-					if @body
-						result = super
-						
-						@callback.call
-						
-						@body = nil
-						
-						return result
+					super.tap do
+						if @callback
+							@callback.call
+							@callback = nil
+						end
 					end
 				end
 				
 				def close(error = nil)
-					if @body
-						super
-						
-						@callback.call(error)
-						
-						@body = nil
+					super.tap do
+						if @callback
+							@callback.call(error)
+							@callback = nil
+						end
 					end
 				end
 			end

--- a/test/protocol/http/body/completable.rb
+++ b/test/protocol/http/body/completable.rb
@@ -5,6 +5,7 @@
 
 require 'protocol/http/body/completable'
 require 'protocol/http/body/buffered'
+require 'protocol/http/request'
 
 describe Protocol::HTTP::Body::Completable do
 	let(:body) {Protocol::HTTP::Body::Buffered.new}
@@ -75,6 +76,11 @@ describe Protocol::HTTP::Body::Completable do
 			2.times do
 				completable.finish
 			end
+		end
+		
+		it "doesn't break #read after finishing" do
+			completable.finish
+			expect(completable.read).to be_nil
 		end
 	end
 end


### PR DESCRIPTION
While experimenting with streaming bodies, I found that in some cases, `Completable` could cause subsequent `#read` to fail. While we should probably fix `#read` too (handle `nil` body), this is probably the best solution.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
