### PR TITLE
Add support for `as_json` to avoid the default Rails implementation.

### DIFF
--- a/lib/protocol/http/body/readable.rb
+++ b/lib/protocol/http/body/readable.rb
@@ -92,6 +92,16 @@ module Protocol
 						return buffer
 					end
 				end
+				
+				def as_json
+					{
+						class: self.class.name,
+						length: self.length,
+						stream: self.stream?,
+						ready: self.ready?,
+						empty: self.empty?
+					}
+				end
 			end
 		end
 	end

--- a/lib/protocol/http/body/wrapper.rb
+++ b/lib/protocol/http/body/wrapper.rb
@@ -51,6 +51,13 @@ module Protocol
 					@body.read
 				end
 				
+				def as_json
+					{
+						class: self.class.name,
+						body: @body&.as_json
+					}
+				end
+				
 				def inspect
 					@body.inspect
 				end

--- a/lib/protocol/http/headers.rb
+++ b/lib/protocol/http/headers.rb
@@ -299,6 +299,8 @@ module Protocol
 				end
 			end
 			
+			alias as_json to_h
+			
 			def inspect
 				"#<#{self.class} #{@fields.inspect}>"
 			end

--- a/lib/protocol/http/request.rb
+++ b/lib/protocol/http/request.rb
@@ -73,6 +73,19 @@ module Protocol
 				@method != Methods::POST && (@body.nil? || @body.empty?)
 			end
 			
+			def as_json
+				{
+					scheme: @scheme,
+					authority: @authority,
+					method: @method,
+					path: @path,
+					version: @version,
+					headers: @headers&.as_json,
+					body: @body&.as_json,
+					protocol: @protocol
+				}
+			end
+			
 			def to_s
 				"#{@scheme}://#{@authority}: #{@method} #{@path} #{@version}"
 			end

--- a/lib/protocol/http/response.rb
+++ b/lib/protocol/http/response.rb
@@ -104,6 +104,16 @@ module Protocol
 				Response[500, Headers['content-type' => 'text/plain'], ["#{exception.class}: #{exception.message}"]]
 			end
 			
+			def as_json
+				{
+					version: @version,
+					status: @status,
+					headers: @headers&.as_json,
+					body: @body&.as_json,
+					protocol: @protocol
+				}
+			end
+			
 			def to_s
 				"#{@status} #{@version}"
 			end

--- a/test/protocol/http/body/wrapper.rb
+++ b/test/protocol/http/body/wrapper.rb
@@ -63,4 +63,13 @@ describe Protocol::HTTP::Body::Wrapper do
 			expect(message.body).to be_a(Protocol::HTTP::Body::Wrapper)
 		end
 	end
+	
+	with "#as_json" do
+		it "generates a JSON representation" do
+			expect(body.as_json).to have_keys(
+				class: be == "Protocol::HTTP::Body::Wrapper",
+				body: be == source.as_json
+			)
+		end
+	end
 end

--- a/test/protocol/http/request.rb
+++ b/test/protocol/http/request.rb
@@ -25,6 +25,21 @@ describe Protocol::HTTP::Request do
 			)
 		end
 		
+		with "#as_json" do
+			it "generates a JSON representation" do
+				expect(request.as_json).to be == {
+					scheme: "http",
+					authority: "localhost",
+					method: "GET",
+					path: "/index.html",
+					version: "HTTP/1.0",
+					headers: headers.as_json,
+					body: nil,
+					protocol: nil
+				}
+			end
+		end
+		
 		it "should not be HEAD" do
 			expect(request).not.to be(:head?)
 		end

--- a/test/protocol/http/response.rb
+++ b/test/protocol/http/response.rb
@@ -13,6 +13,7 @@ describe Protocol::HTTP::Response do
 	InformationalResponse = Sus::Shared("informational response") do
 		it "should be informational" do
 			expect(response).to be(:informational?)
+			expect(response.as_json).to have_keys(status: be_within(100...200))
 		end
 		
 		it "should not be a failure" do
@@ -23,6 +24,7 @@ describe Protocol::HTTP::Response do
 	SuccessfulResponse = Sus::Shared("successful response") do
 		it "should be successful" do
 			expect(response).to be(:success?)
+			expect(response.as_json).to have_keys(status: be_within(200...300))
 		end
 		
 		it "should be final" do
@@ -45,6 +47,7 @@ describe Protocol::HTTP::Response do
 		
 		it "should be a redirection" do
 			expect(response).to be(:redirection?)
+			expect(response.as_json).to have_keys(status: be_within(300...400))
 		end
 		
 		it "should not be informational" do
@@ -71,6 +74,7 @@ describe Protocol::HTTP::Response do
 		
 		it "should be a failure" do
 			expect(response).to be(:failure?)
+			expect(response.as_json).to have_keys(status: be_within(400...600))
 		end
 	end
 	
@@ -97,6 +101,18 @@ describe Protocol::HTTP::Response do
 				body: be == nil,
 				protocol: be == nil
 			)
+		end
+		
+		with "#as_json" do
+			it "generates a JSON representation" do
+				expect(response.as_json).to have_keys(
+					version: be == "HTTP/1.1",
+					status: be == 100,
+					headers: be == headers.as_json,
+					body: be == nil,
+					protocol: be == nil,
+				)
+			end
 		end
 		
 		it_behaves_like InformationalResponse
@@ -143,6 +159,7 @@ describe Protocol::HTTP::Response do
 	end
 	
 	with "200 OK" do
+		let(:body) {Protocol::HTTP::Body::Buffered.wrap("Hello, World!")}
 		let(:response) {subject.new("HTTP/1.0", 200, headers, body)}
 		
 		it "should have attributes" do
@@ -153,6 +170,18 @@ describe Protocol::HTTP::Response do
 				body: be == body,
 				protocol: be == nil
 			)
+		end
+		
+		with "#as_json" do
+			it "generates a JSON representation" do
+				expect(response.as_json).to have_keys(
+					version: be == "HTTP/1.0",
+					status: be == 200,
+					headers: be == headers.as_json,
+					body: be == body.as_json,
+					protocol: be == nil,
+				)
+			end
 		end
 		
 		it_behaves_like SuccessfulResponse


### PR DESCRIPTION
The default Rails implementation will try to convert all instance variables `as_json` which is inappropriate in some cases and can cause `Stack level too deep (SystemStackError)`.

Fixes <https://github.com/socketry/async-http/issues/156>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
