### PR TITLE
`as_json` should ignore all arguments. Add default `to_json`.

### DIFF
--- a/lib/protocol/http/body/readable.rb
+++ b/lib/protocol/http/body/readable.rb
@@ -93,7 +93,7 @@ module Protocol
 					end
 				end
 				
-				def as_json
+				def as_json(...)
 					{
 						class: self.class.name,
 						length: self.length,
@@ -101,6 +101,10 @@ module Protocol
 						ready: self.ready?,
 						empty: self.empty?
 					}
+				end
+				
+				def to_json(...)
+					as_json.to_json(...)
 				end
 			end
 		end

--- a/lib/protocol/http/body/wrapper.rb
+++ b/lib/protocol/http/body/wrapper.rb
@@ -51,11 +51,15 @@ module Protocol
 					@body.read
 				end
 				
-				def as_json
+				def as_json(...)
 					{
 						class: self.class.name,
 						body: @body&.as_json
 					}
+				end
+				
+				def to_json(...)
+					as_json.to_json(...)
 				end
 				
 				def inspect

--- a/lib/protocol/http/request.rb
+++ b/lib/protocol/http/request.rb
@@ -73,7 +73,7 @@ module Protocol
 				@method != Methods::POST && (@body.nil? || @body.empty?)
 			end
 			
-			def as_json
+			def as_json(...)
 				{
 					scheme: @scheme,
 					authority: @authority,
@@ -84,6 +84,10 @@ module Protocol
 					body: @body&.as_json,
 					protocol: @protocol
 				}
+			end
+			
+			def to_json(...)
+				as_json.to_json(...)
 			end
 			
 			def to_s

--- a/lib/protocol/http/response.rb
+++ b/lib/protocol/http/response.rb
@@ -104,7 +104,7 @@ module Protocol
 				Response[500, Headers['content-type' => 'text/plain'], ["#{exception.class}: #{exception.message}"]]
 			end
 			
-			def as_json
+			def as_json(...)
 				{
 					version: @version,
 					status: @status,
@@ -112,6 +112,10 @@ module Protocol
 					body: @body&.as_json,
 					protocol: @protocol
 				}
+			end
+			
+			def to_json(...)
+				as_json.to_json(...)
 			end
 			
 			def to_s

--- a/test/protocol/http/body/readable.rb
+++ b/test/protocol/http/body/readable.rb
@@ -42,4 +42,20 @@ describe Protocol::HTTP::Body::Readable do
 			expect(body.join).to be_nil
 		end
 	end
+	
+	with "#as_json" do
+		it "generates a JSON representation" do
+			expect(body.as_json).to have_keys(
+				class: be == subject.name,
+				length: be_nil,
+				stream: be == false,
+				ready: be == false,
+				empty: be == false,
+			)
+		end
+		
+		it "generates a JSON string" do
+			expect(JSON.dump(body)).to be == body.to_json
+		end
+	end
 end

--- a/test/protocol/http/body/wrapper.rb
+++ b/test/protocol/http/body/wrapper.rb
@@ -71,5 +71,9 @@ describe Protocol::HTTP::Body::Wrapper do
 				body: be == source.as_json
 			)
 		end
+		
+		it "generates a JSON string" do
+			expect(JSON.dump(body)).to be == body.to_json
+		end
 	end
 end

--- a/test/protocol/http/request.rb
+++ b/test/protocol/http/request.rb
@@ -5,6 +5,8 @@
 
 require 'protocol/http/request'
 
+require 'json'
+
 describe Protocol::HTTP::Request do
 	let(:headers) {Protocol::HTTP::Headers.new}
 	let(:body) {nil}
@@ -37,6 +39,10 @@ describe Protocol::HTTP::Request do
 					body: nil,
 					protocol: nil
 				}
+			end
+			
+			it "generates a JSON string" do
+				expect(JSON.dump(request)).to be == request.to_json
 			end
 		end
 		

--- a/test/protocol/http/response.rb
+++ b/test/protocol/http/response.rb
@@ -113,6 +113,10 @@ describe Protocol::HTTP::Response do
 					protocol: be == nil,
 				)
 			end
+			
+			it "generates a JSON string" do
+				expect(JSON.dump(response)).to be == response.to_json
+			end
 		end
 		
 		it_behaves_like InformationalResponse
@@ -181,6 +185,10 @@ describe Protocol::HTTP::Response do
 					body: be == body.as_json,
 					protocol: be == nil,
 				)
+			end
+			
+			it "generates a JSON string" do
+				expect(JSON.dump(response)).to be == response.to_json
 			end
 		end
 		


### PR DESCRIPTION
Follow up to <https://github.com/socketry/protocol-http/pull/53>.

`def as_json(...)` should accept and ignore all arguments.

We should add a default `to_json` -> `as_json.to_json(...)` too, otherwise, `JSON.dump` won't use it.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
