### PR TITLE
Fail if the key path is empty.

### DIFF
--- a/lib/protocol/http/url.rb
+++ b/lib/protocol/http/url.rb
@@ -65,9 +65,13 @@ module Protocol
 			end
 			
 			def self.split(name)
-				name.scan(/([^\[]+)|(?:\[(.*?)\])/).flatten!.compact!
+				name.scan(/([^\[]+)|(?:\[(.*?)\])/)&.tap do |parts|
+					parts.flatten!
+					parts.compact!
+				end
 			end
 			
+			# Assign a value to a nested hash.
 			def self.assign(keys, value, parent)
 				top, *middle = keys
 				
@@ -94,6 +98,10 @@ module Protocol
 				
 				self.scan(string) do |name, value|
 					keys = self.split(name)
+					
+					if keys.empty?
+						raise ArgumentError, "Invalid key path: #{name.inspect}!"
+					end
 					
 					if keys.size > maximum
 						raise ArgumentError, "Key length exceeded limit!"

--- a/test/protocol/http/url.rb
+++ b/test/protocol/http/url.rb
@@ -70,6 +70,12 @@ describe Protocol::HTTP::URL do
 				Protocol::HTTP::URL.decode("a[b][c][d][e][f][g][h][i]=10")
 			end.to raise_exception(ArgumentError, message: be =~ /Key length exceeded/)
 		end
+		
+		it "fails with missing key" do
+			expect do
+				Protocol::HTTP::URL.decode("=foo")
+			end.to raise_exception(ArgumentError, message: be =~ /Invalid key/)
+		end
 	end
 
 	with '.unescape' do


### PR DESCRIPTION
Fixes <https://github.com/socketry/protocol-http/issues/56>.

We could accept `nil` keys, but there is no way to reasonably format it, e.g. consider `{nil => {nil => "foo"}}` would format, hypothetically, as `[]=foo` which would decode as `{nil => ["foo"]}`. I can't see any way to disambiguate the situation.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
