### PR TITLE
Support output buffer in `read_partial`/`readpartial`.

### DIFF
--- a/lib/protocol/http/body/stream.rb
+++ b/lib/protocol/http/body/stream.rb
@@ -89,12 +89,22 @@ module Protocol
 					# Will avoid reading from the underlying stream if there is buffered data available.
 					#
 					# @parameter length [Integer] The maximum number of bytes to read.
-					def read_partial(length = nil)
+					def read_partial(length = nil, buffer = nil)
 						if @buffer
-							buffer = @buffer
-							@buffer = nil
+							if buffer
+								buffer.replace(@buffer)
+							else
+								buffer = @buffer
+								@buffer = nil
+							end
 						else
-							buffer = read_next
+							chunk = read_next
+							
+							if buffer and chunk
+								buffer.replace(chunk)
+							else
+								buffer = chunk
+							end
 						end
 						
 						if buffer and length
@@ -111,8 +121,8 @@ module Protocol
 					end
 					
 					# Similar to {read_partial} but raises an `EOFError` if the stream is at EOF.
-					def readpartial(length)
-						read_partial(length) or raise EOFError, "End of file reached!"
+					def readpartial(length, buffer = nil)
+						read_partial(length, buffer) or raise EOFError, "End of file reached!"
 					end
 					
 					# Read data from the stream without blocking if possible.

--- a/lib/protocol/http/body/stream.rb
+++ b/lib/protocol/http/body/stream.rb
@@ -95,15 +95,18 @@ module Protocol
 								buffer.replace(@buffer)
 							else
 								buffer = @buffer
-								@buffer = nil
 							end
+							@buffer = nil
 						else
-							chunk = read_next
-							
-							if buffer and chunk
-								buffer.replace(chunk)
+							if chunk = read_next
+								if buffer
+									buffer.replace(chunk)
+								else
+									buffer = chunk
+								end
 							else
-								buffer = chunk
+								buffer&.clear
+								buffer = nil
 							end
 						end
 						

--- a/test/protocol/http/body/stream.rb
+++ b/test/protocol/http/body/stream.rb
@@ -147,6 +147,16 @@ describe Protocol::HTTP::Body::Stream do
 			expect(stream.readpartial(20)).to be == "World"
 			expect{stream.readpartial(20)}.to raise_exception(EOFError)
 		end
+		
+		it "can read partial input with buffer" do
+			buffer = String.new
+			expect(stream.readpartial(20, buffer)).to be == "Hello"
+			expect(buffer).to be == "Hello"
+			expect(stream.readpartial(20, buffer)).to be == "World"
+			expect(buffer).to be == "World"
+			expect{stream.readpartial(20, buffer)}.to raise_exception(EOFError)
+			expect(buffer).to be == ""
+		end
 	end
 	
 	with '#read_until' do

--- a/test/protocol/http/body/stream.rb
+++ b/test/protocol/http/body/stream.rb
@@ -121,6 +121,24 @@ describe Protocol::HTTP::Body::Stream do
 			expect(stream.read_partial(2)).to be == "d"
 			expect(stream.read_partial(2)).to be == nil
 		end
+		
+		it "can read partial input with buffer" do
+			buffer = String.new
+			expect(stream.read_partial(2, buffer)).to be == "He"
+			expect(buffer).to be == "He"
+			expect(stream.read_partial(2, buffer)).to be == "ll"
+			expect(buffer).to be == "ll"
+			expect(stream.read_partial(2, buffer)).to be == "o"
+			expect(buffer).to be == "o"
+			expect(stream.read_partial(2, buffer)).to be == "Wo"
+			expect(buffer).to be == "Wo"
+			expect(stream.read_partial(2, buffer)).to be == "rl"
+			expect(buffer).to be == "rl"
+			expect(stream.read_partial(2, buffer)).to be == "d"
+			expect(buffer).to be == "d"
+			expect(stream.read_partial(2, buffer)).to be == nil
+			expect(buffer).to be == ""
+		end
 	end
 	
 	with '#readpartial' do

--- a/test/protocol/http/body/stream.rb
+++ b/test/protocol/http/body/stream.rb
@@ -224,4 +224,14 @@ describe Protocol::HTTP::Body::Stream do
 			expect(stream).to be(:closed?)
 		end
 	end
+	
+	with 'IO.copy_stream' do
+		let(:output) {StringIO.new}
+		
+		it "can copy input to output" do
+			::IO.copy_stream(stream, output)
+			
+			expect(output.string).to be == "HelloWorld"
+		end
+	end
 end


### PR DESCRIPTION
Using `IO.copy_stream` with a `Protocol::HTTP::Body::Stream` fails because `readpartial` doesn't take the "outbuf" argument. Let's fix that.

Fixes <https://github.com/socketry/protocol-http/issues/62>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
