### PR TITLE
Interim response handling

### DIFF
--- a/guides/design-overview/readme.md
+++ b/guides/design-overview/readme.md
@@ -189,3 +189,21 @@ response.read -> "dlroW olleH"
 ~~~
 
 The value of this uni-directional flow is that it is natural for the stream to be taken out of the scope imposed by the nested `call(request)` model. However, the user must explicitly close the stream, since it's no longer scoped to the client and/or server.
+
+## Interim Response Handling
+
+Interim responses are responses that are sent before the final response. They are used for things like `103 Early Hints` and `100 Continue`. These responses are sent before the final response, and are used to signal to the client that the server is still processing the request.
+
+```ruby
+body = Body::Writable.new
+
+interim_response_callback = proc do |status, headers|
+	if status == 100
+		# Continue sending the request body.
+		body.write("Hello World")
+		body.close
+	end
+end
+
+response = client.post("/upload", {'expect' => '100-continue'}, body, interim_response: interim_response_callback)
+```

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,7 @@ Please see the [project releases](https://socketry.github.io/protocol-http/relea
 ### Unreleased
 
   - [`Request[]` and `Response[]` Keyword Arguments](https://socketry.github.io/protocol-http/releases/index#request[]-and-response[]-keyword-arguments)
+  - [Interim Response Handling](https://socketry.github.io/protocol-http/releases/index#interim-response-handling)
 
 ## See Also
 

--- a/releases.md
+++ b/releases.md
@@ -13,5 +13,28 @@ client.get("/", headers: {"accept" => "text/html"}, authority: "example.com")
 # Response keyword arguments:
 def call(request)
 	return Response[200, headers: {"content-Type" => "text/html"}, body: "Hello, World!"]
+```
+
+### Interim Response Handling
+
+The `Request` class now exposes a `#interim_response` attribute which can be used to handle interim responses both on the client side and server side.
+
+On the client side, you can pass a callback using the `interim_response` keyword argument which will be invoked whenever an interim response is received:
+
+```ruby
+client = ...
+response = client.get("/index", interim_response: proc{|status, headers| ...})
+```
+
+On the server side, you can send an interim response using the `#send_interim_response` method:
+
+```ruby
+def call(request)
+	if request.headers["expect"] == "100-continue"
+		# Send an interim response:
+		request.send_interim_response(100)
+	end
+	
+	# ...
 end
 ```

--- a/test/protocol/http/request.rb
+++ b/test/protocol/http/request.rb
@@ -121,4 +121,39 @@ describe Protocol::HTTP::Request do
 			request.call(connection)
 		end
 	end
+	
+	with "interim response" do
+		let(:request) {subject.new("http", "localhost", "GET", "/index.html", "HTTP/1.0", headers, body)}
+		
+		it "should call block" do
+			request.on_interim_response do |status, headers|
+				expect(status).to be == 100
+				expect(headers).to be == {}
+			end
+			
+			request.send_interim_response(100, {})
+		end
+		
+		it "calls multiple blocks" do
+			sequence = []
+			
+			request.on_interim_response do |status, headers|
+				sequence << 1
+				
+				expect(status).to be == 100
+				expect(headers).to be == {}
+			end
+			
+			request.on_interim_response do |status, headers|
+				sequence << 2
+				
+				expect(status).to be == 100
+				expect(headers).to be == {}
+			end
+			
+			request.send_interim_response(100, {})
+			
+			expect(sequence).to be == [2, 1]
+		end
+	end
 end


### PR DESCRIPTION
This introduces a semantic for handling interim responses.

Interim responses have a status code of 1xx (excluding 101 upgrade). In theory it's okay to ignore them, so this interface is designed to be optional.

It exposes interim responses in a way that is compatible with both the client and server side.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
