### PR TITLE
Support for keyword arguments for `Request`/`Response`.

### DIFF
--- a/lib/protocol/http/methods.rb
+++ b/lib/protocol/http/methods.rb
@@ -70,9 +70,9 @@ module Protocol
 			end
 			
 			self.each do |name, value|
-				define_method(name) do |location, headers = nil, body = nil|
+				define_method(name) do |location, *arguments, **options|
 					self.call(
-						Request[value, location.to_s, Headers[headers], body]
+						Request[value, location.to_s, *arguments, **options]
 					)
 				end
 			end

--- a/lib/protocol/http/request.rb
+++ b/lib/protocol/http/request.rb
@@ -81,11 +81,11 @@ module Protocol
 			# @parameter path [String] The path, e.g. `"/index.html"`, `"/search?q=hello"`, etc.
 			# @parameter headers [Hash] The headers, e.g. `{"accept" => "text/html"}`, etc.
 			# @parameter body [String | Array(String) | Body::Readable] The body, e.g. `"Hello, World!"`, etc. See {Body::Buffered.wrap} for more information about .
-			def self.[](method, path, headers = nil, body = nil)
+			def self.[](method, path, _headers = nil, _body = nil, scheme: nil, authority: nil, headers: _headers, body: _body, protocol: nil)
 				body = Body::Buffered.wrap(body)
-				headers = ::Protocol::HTTP::Headers[headers]
+				headers = Headers[headers]
 				
-				self.new(nil, nil, method, path, nil, headers, body)
+				self.new(scheme, authority, method, path, nil, headers, body, protocol)
 			end
 			
 			# Whether the request can be replayed without side-effects.

--- a/lib/protocol/http/response.rb
+++ b/lib/protocol/http/response.rb
@@ -130,9 +130,9 @@ module Protocol
 			# @parameter status [Integer] The HTTP status code, e.g. `200`, `404`, etc.
 			# @parameter headers [Hash] The headers, e.g. `{"content-type" => "text/html"}`, etc.
 			# @parameter body [String | Array(String) | Body::Readable] The body, e.g. `"Hello, World!"`, etc. See {Body::Buffered.wrap} for more information about .
-			def self.[](status, headers = nil, body = nil, protocol = nil)
+			def self.[](status, _headers = nil, _body = nil, headers: _headers, body: _body, protocol: nil)
 				body = Body::Buffered.wrap(body)
-				headers = ::Protocol::HTTP::Headers[headers]
+				headers = Headers[headers]
 				
 				self.new(nil, status, headers, body, protocol)
 			end

--- a/test/protocol/http/request.rb
+++ b/test/protocol/http/request.rb
@@ -11,6 +11,57 @@ describe Protocol::HTTP::Request do
 	let(:headers) {Protocol::HTTP::Headers.new}
 	let(:body) {nil}
 	
+	with ".[]" do
+		let(:body) {Protocol::HTTP::Body::Buffered.wrap("Hello, World!")}
+		let(:headers) {Protocol::HTTP::Headers[{"accept" => "text/html"}]}
+		
+		it "creates a new request" do
+			request = subject["GET", "/index.html", headers]
+			
+			expect(request).to have_attributes(
+				scheme: be_nil,
+				authority: be_nil,
+				method: be == "GET",
+				path: be == "/index.html",
+				version: be_nil,
+				headers: be == headers,
+				body: be_nil,
+				protocol: be_nil
+			)
+		end
+		
+		it "creates a new request with keyword arguments" do
+			request = subject["GET", "/index.html", scheme: "http", authority: "localhost", headers: headers, body: body]
+			
+			expect(request).to have_attributes(
+				scheme: be == "http",
+				authority: be == "localhost",
+				method: be == "GET",
+				path: be == "/index.html",
+				version: be_nil,
+				headers: be == headers,
+				body: be == body,
+				protocol: be_nil
+			)
+		end
+		
+		it "converts header hash to headers instance" do
+			request = subject["GET", "/index.html", {"accept" => "text/html"}]
+			
+			expect(request).to have_attributes(
+				headers: be == headers,
+			)
+		end
+		
+		it "converts array body to buffered body" do
+			request = subject["GET", "/index.html", headers: headers, body: ["Hello, World!"]]
+			
+			expect(request).to have_attributes(
+				body: be_a(Protocol::HTTP::Body::Buffered)
+			)
+		end
+	end
+	
 	with "simple GET request" do
 		let(:request) {subject.new("http", "localhost", "GET", "/index.html", "HTTP/1.0", headers, body)}
 		
@@ -23,7 +74,7 @@ describe Protocol::HTTP::Request do
 				version: be == "HTTP/1.0",
 				headers: be == headers,
 				body: be == body,
-				protocol: be == nil
+				protocol: be_nil
 			)
 		end
 		

--- a/test/protocol/http/response.rb
+++ b/test/protocol/http/response.rb
@@ -275,4 +275,49 @@ describe Protocol::HTTP::Response do
 			expect(response).to be(:not_modified?)
 		end
 	end
+	
+	with ".[]" do
+		let(:body) {Protocol::HTTP::Body::Buffered.wrap("Hello, World!")}
+		let(:headers) {Protocol::HTTP::Headers[{"accept" => "text/html"}]}
+		
+		it "creates a new response" do
+			response = subject[200, headers]
+			
+			expect(response).to have_attributes(
+				version: be_nil,
+				status: be == 200,
+				headers: be == headers,
+				body: be_nil,
+				protocol: be_nil
+			)
+		end
+		
+		it "creates a new response with keyword arguments" do
+			response = subject[200, headers: headers, body: body]
+			
+			expect(response).to have_attributes(
+				version: be_nil,
+				status: be == 200,
+				headers: be == headers,
+				body: be == body,
+				protocol: be_nil
+			)
+		end
+		
+		it "converts header hash to headers instance" do
+			response = subject[200, {"accept" => "text/html"}]
+			
+			expect(response).to have_attributes(
+				headers: be == headers,
+			)
+		end
+		
+		it "converts array body to buffered body" do
+			response = subject[200, headers: headers, body: ["Hello, World!"]]
+			
+			expect(response).to have_attributes(
+				body: be_a(Protocol::HTTP::Body::Buffered)
+			)
+		end
+	end
 end


### PR DESCRIPTION
It can be tricky to specify positional arguments as `Request` (especially) and `Response` take several arguments, some of which are not always specified.

We introduce support for keyword arguments which makes it easier to read and write code which deals with complex request/response scenarios.

```ruby
client.get("/index.html", headers: ..., authority: ...)
```

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
