### PR TITLE
Improved streamable body implementation.

### DIFF
--- a/examples/streaming/bidirectional.rb
+++ b/examples/streaming/bidirectional.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'async'
 require 'async/http/client'

--- a/examples/streaming/bidirectional.rb
+++ b/examples/streaming/bidirectional.rb
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+
+require 'async'
+require 'async/http/client'
+require 'async/http/server'
+require 'async/http/endpoint'
+
+require 'protocol/http/body/streamable'
+require 'protocol/http/body/writable'
+require 'protocol/http/body/stream'
+
+endpoint = Async::HTTP::Endpoint.parse('http://localhost:3000')
+
+Async do
+	server = Async::HTTP::Server.for(endpoint) do |request|
+		output = Protocol::HTTP::Body::Streamable.response(request) do |stream|
+			# Simple echo server:
+			while chunk = stream.readpartial(1024)
+				stream.write(chunk)
+			end
+		rescue EOFError
+			# Ignore EOF errors.
+		ensure
+			stream.close
+		end
+		
+		Protocol::HTTP::Response[200, {}, output]
+	end
+	
+	server_task = Async{server.run}
+	
+	client = Async::HTTP::Client.new(endpoint)
+	
+	streamable = Protocol::HTTP::Body::Streamable.request do |stream|
+		stream.write("Hello, ")
+		stream.write("World!")
+		stream.close_write
+		
+		while chunk = stream.readpartial(1024)
+			puts chunk
+		end
+	rescue EOFError
+		# Ignore EOF errors.
+	ensure
+		stream.close
+	end
+	
+	response = client.get("/", body: streamable)
+	streamable.stream(response.body)
+ensure
+	server_task.stop
+end

--- a/examples/streaming/bidirectional.rb
+++ b/examples/streaming/bidirectional.rb
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# Released under the MIT License.
+# Copyright, 2024, by Samuel Williams.
+
 require 'async'
 require 'async/http/client'
 require 'async/http/server'

--- a/examples/streaming/gems.locked
+++ b/examples/streaming/gems.locked
@@ -1,0 +1,57 @@
+PATH
+  remote: ../..
+  specs:
+    protocol-http (0.33.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    async (2.17.0)
+      console (~> 1.26)
+      fiber-annotation
+      io-event (~> 1.6, >= 1.6.5)
+    async-http (0.75.0)
+      async (>= 2.10.2)
+      async-pool (~> 0.7)
+      io-endpoint (~> 0.11)
+      io-stream (~> 0.4)
+      protocol-http (~> 0.30)
+      protocol-http1 (~> 0.20)
+      protocol-http2 (~> 0.18)
+      traces (>= 0.10)
+    async-pool (0.8.1)
+      async (>= 1.25)
+      metrics
+      traces
+    console (1.27.0)
+      fiber-annotation
+      fiber-local (~> 1.1)
+      json
+    fiber-annotation (0.2.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (1.0.0)
+    io-endpoint (0.13.1)
+    io-event (1.6.5)
+    io-stream (0.4.0)
+    json (2.7.2)
+    metrics (0.10.2)
+    protocol-hpack (1.5.0)
+    protocol-http1 (0.22.0)
+      protocol-http (~> 0.22)
+    protocol-http2 (0.18.0)
+      protocol-hpack (~> 1.4)
+      protocol-http (~> 0.18)
+    traces (0.13.1)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  async
+  async-http
+  protocol-http!
+
+BUNDLED WITH
+   2.5.16

--- a/examples/streaming/gems.rb
+++ b/examples/streaming/gems.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source "https://rubygems.org"
 
 gem "async"

--- a/examples/streaming/gems.rb
+++ b/examples/streaming/gems.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2024, by Samuel Williams.
+
 source "https://rubygems.org"
 
 gem "async"

--- a/examples/streaming/gems.rb
+++ b/examples/streaming/gems.rb
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "async"
+gem "async-http"
+gem "protocol-http", path: "../../"

--- a/examples/streaming/unidirectional.rb
+++ b/examples/streaming/unidirectional.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'async'
 require 'async/http/client'

--- a/examples/streaming/unidirectional.rb
+++ b/examples/streaming/unidirectional.rb
@@ -1,0 +1,56 @@
+#!/usr/bin/env ruby
+
+require 'async'
+require 'async/http/client'
+require 'async/http/server'
+require 'async/http/endpoint'
+
+require 'protocol/http/body/stream'
+require 'protocol/http/body/writable'
+
+endpoint = Async::HTTP::Endpoint.parse('http://localhost:3000')
+
+Async do
+	server = Async::HTTP::Server.for(endpoint) do |request|
+		output = Protocol::HTTP::Body::Writable.new
+		stream = Protocol::HTTP::Body::Stream.new(request.body, output)
+		
+		Async do
+			# Simple echo server:
+			while chunk = stream.readpartial(1024)
+				stream.write(chunk)
+			end
+		rescue EOFError
+			# Ignore EOF errors.
+		ensure
+			stream.close
+		end
+		
+		Protocol::HTTP::Response[200, {}, output]
+	end
+	
+	server_task = Async{server.run}
+	
+	client = Async::HTTP::Client.new(endpoint)
+	
+	input = Protocol::HTTP::Body::Writable.new
+	response = client.get("/", body: input)
+	
+	begin
+		stream = Protocol::HTTP::Body::Stream.new(response.body, input)
+		
+		stream.write("Hello, ")
+		stream.write("World!")
+		stream.close_write
+		
+		while chunk = stream.readpartial(1024)
+			puts chunk
+		end
+	rescue EOFError
+		# Ignore EOF errors.
+	ensure
+		stream.close
+	end
+ensure
+	server_task.stop
+end

--- a/examples/streaming/unidirectional.rb
+++ b/examples/streaming/unidirectional.rb
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# Released under the MIT License.
+# Copyright, 2024, by Samuel Williams.
+
 require 'async'
 require 'async/http/client'
 require 'async/http/server'

--- a/fixtures/protocol/http/body/a_readable_body.rb
+++ b/fixtures/protocol/http/body/a_readable_body.rb
@@ -1,0 +1,14 @@
+module Protocol
+	module HTTP
+		module Body
+			AReadableBody = Sus::Shared("a readable body") do
+				with "#close" do
+					it "should close the body" do
+						body.close
+						expect(body.read).to be_nil
+					end
+				end
+			end
+		end
+	end
+end

--- a/fixtures/protocol/http/body/a_readable_body.rb
+++ b/fixtures/protocol/http/body/a_readable_body.rb
@@ -1,11 +1,25 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2024, by Samuel Williams.
+
 module Protocol
 	module HTTP
 		module Body
 			AReadableBody = Sus::Shared("a readable body") do
-				with "#close" do
-					it "should close the body" do
+				with "#read" do
+					it "after closing, returns nil" do
 						body.close
+						
 						expect(body.read).to be_nil
+					end
+				end
+				
+				with "empty?" do
+					it "returns true after closing" do
+						body.close
+						
+						expect(body).to be(:empty?)
 					end
 				end
 			end

--- a/fixtures/protocol/http/body/a_writable_body.rb
+++ b/fixtures/protocol/http/body/a_writable_body.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2024, by Samuel Williams.
+
+module Protocol
+	module HTTP
+		module Body
+			AWritableBody = Sus::Shared("a readable body") do
+				with "#read" do
+					it "after closing the write end, returns all chunks" do
+						body.write("Hello ")
+						body.write("World!")
+						body.close_write
+						
+						expect(body.read).to be == "Hello "
+						expect(body.read).to be == "World!"
+						expect(body.read).to be_nil
+					end
+				end
+				
+				with "empty?" do
+					it "returns false before writing" do
+						expect(body).not.to be(:empty?)
+					end
+					
+					it "returns true after all chunks are consumed" do
+						body.write("Hello")
+						body.close_write
+						
+						expect(body).not.to be(:empty?)
+						expect(body.read).to be == "Hello"
+						expect(body.read).to be_nil
+						
+						expect(body).to be(:empty?)
+					end
+				end
+			end
+		end
+	end
+end

--- a/guides/links.yaml
+++ b/guides/links.yaml
@@ -1,4 +1,4 @@
 getting-started:
   order: 1
 design-overview:
-  order: 2
+  order: 10

--- a/guides/streaming/readme.md
+++ b/guides/streaming/readme.md
@@ -1,0 +1,131 @@
+# Streaming
+
+This guide gives an overview of how to implement streaming requests and responses.
+
+## Independent Uni-directional Streaming
+
+The request and response body work independently of each other can stream data in both directions. {ruby Protocol::HTTP::Body::Stream} provides an interface to merge these independent streams into an IO-like interface.
+
+```ruby
+#!/usr/bin/env ruby
+
+require 'async'
+require 'async/http/client'
+require 'async/http/server'
+require 'async/http/endpoint'
+
+require 'protocol/http/body/stream'
+require 'protocol/http/body/writable'
+
+endpoint = Async::HTTP::Endpoint.parse('http://localhost:3000')
+
+Async do
+	server = Async::HTTP::Server.for(endpoint) do |request|
+		output = Protocol::HTTP::Body::Writable.new
+		stream = Protocol::HTTP::Body::Stream.new(request.body, output)
+		
+		Async do
+			# Simple echo server:
+			while chunk = stream.readpartial(1024)
+				stream.write(chunk)
+			end
+		rescue EOFError
+			# Ignore EOF errors.
+		ensure
+			stream.close
+		end
+		
+		Protocol::HTTP::Response[200, {}, output]
+	end
+	
+	server_task = Async{server.run}
+	
+	client = Async::HTTP::Client.new(endpoint)
+	
+	input = Protocol::HTTP::Body::Writable.new
+	response = client.get("/", body: input)
+	
+	begin
+		stream = Protocol::HTTP::Body::Stream.new(response.body, input)
+		
+		stream.write("Hello, ")
+		stream.write("World!")
+		stream.close_write
+		
+		while chunk = stream.readpartial(1024)
+			puts chunk
+		end
+	rescue EOFError
+		# Ignore EOF errors.
+	ensure
+		stream.close
+	end
+ensure
+	server_task.stop
+end
+```
+
+This approach works quite well, especially when the input and output bodies are independently compressed, decompressed, or chunked. However, some protocols, notably, WebSockets operate on the raw connection and don't require this level of abstraction.
+
+## Bi-directional Streaming
+
+While WebSockets can work on the above streaming interface, it's a bit more convenient to use the streaming interface directly, which gives raw access to the underlying stream where possible.
+
+```ruby
+#!/usr/bin/env ruby
+
+require 'async'
+require 'async/http/client'
+require 'async/http/server'
+require 'async/http/endpoint'
+
+require 'protocol/http/body/stream'
+require 'protocol/http/body/writable'
+
+endpoint = Async::HTTP::Endpoint.parse('http://localhost:3000')
+
+Async do
+	server = Async::HTTP::Server.for(endpoint) do |request|
+		streamable = Protocol::HTTP::Body::Streamable.
+		output = Protocol::HTTP::Body::Writable.new
+		stream = Protocol::HTTP::Body::Stream.new(request.body, output)
+		
+		Async do
+			# Simple echo server:
+			while chunk = stream.readpartial(1024)
+				stream.write(chunk)
+			end
+		rescue EOFError
+			# Ignore EOF errors.
+		ensure
+			stream.close
+		end
+		
+		Protocol::HTTP::Response[200, {}, output]
+	end
+	
+	server_task = Async{server.run}
+	
+	client = Async::HTTP::Client.new(endpoint)
+	
+	input = Protocol::HTTP::Body::Writable.new
+	response = client.get("/", body: input)
+	
+	begin
+		stream = Protocol::HTTP::Body::Stream.new(response.body, input)
+		
+		stream.write("Hello, ")
+		stream.write("World!")
+		stream.close_write
+		
+		while chunk = stream.readpartial(1024)
+			puts chunk
+		end
+	rescue EOFError
+		# Ignore EOF errors.
+	ensure
+		stream.close
+	end
+ensure
+	server_task.stop
+end

--- a/lib/protocol/http/body/buffered.rb
+++ b/lib/protocol/http/body/buffered.rb
@@ -52,8 +52,18 @@ module Protocol
 				
 				attr :chunks
 				
+				def finish
+					self
+				end
+				
 				def close(error = nil)
-					@chunks = []
+					@index = @chunks.length
+				end
+				
+				def clear
+					@chunks.clear
+					@length = 0
+					@index = 0
 				end
 				
 				def length
@@ -70,6 +80,8 @@ module Protocol
 				end
 				
 				def read
+					return nil unless @chunks
+					
 					if chunk = @chunks[@index]
 						@index += 1
 						
@@ -81,18 +93,28 @@ module Protocol
 					@chunks << chunk
 				end
 				
+				def close_write(error)
+					# Nothing to do.
+				end
+				
 				def rewindable?
-					true
+					@chunks != nil
 				end
 				
 				def rewind
+					return false unless @chunks
+					
 					@index = 0
 					
 					return true
 				end
 				
 				def inspect
-					"\#<#{self.class} #{@chunks.size} chunks, #{self.length} bytes>"
+					if @chunks
+						"\#<#{self.class} #{@chunks.size} chunks, #{self.length} bytes>"
+					else
+						"\#<#{self.class} closed>"
+					end
 				end
 			end
 		end

--- a/lib/protocol/http/body/buffered.rb
+++ b/lib/protocol/http/body/buffered.rb
@@ -52,8 +52,8 @@ module Protocol
 				
 				attr :chunks
 				
-				def finish
-					self
+				def close(error = nil)
+					@chunks = []
 				end
 				
 				def length

--- a/lib/protocol/http/body/buffered.rb
+++ b/lib/protocol/http/body/buffered.rb
@@ -56,6 +56,7 @@ module Protocol
 					self
 				end
 				
+				# Ensure that future reads return nil, but allow for rewinding.
 				def close(error = nil)
 					@index = @chunks.length
 				end
@@ -112,8 +113,6 @@ module Protocol
 				def inspect
 					if @chunks
 						"\#<#{self.class} #{@chunks.size} chunks, #{self.length} bytes>"
-					else
-						"\#<#{self.class} closed>"
 					end
 				end
 			end

--- a/lib/protocol/http/body/deflate.rb
+++ b/lib/protocol/http/body/deflate.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2019-2023, by Samuel Williams.
+# Copyright, 2019-2024, by Samuel Williams.
 
 require_relative 'wrapper'
 

--- a/lib/protocol/http/body/digestable.rb
+++ b/lib/protocol/http/body/digestable.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2020-2023, by Samuel Williams.
+# Copyright, 2020-2024, by Samuel Williams.
 
 require_relative 'wrapper'
 

--- a/lib/protocol/http/body/file.rb
+++ b/lib/protocol/http/body/file.rb
@@ -68,15 +68,15 @@ module Protocol
 					end
 				end
 				
-				def stream?
-					true
-				end
+				# def stream?
+				# 	true
+				# end
 				
-				def call(stream)
-					IO.copy_stream(@file, stream, @remaining)
-				ensure
-					stream.close
-				end
+				# def call(stream)
+				# 	IO.copy_stream(@file, stream, @remaining)
+				# ensure
+				# 	stream.close
+				# end
 				
 				def join
 					return "" if @remaining == 0

--- a/lib/protocol/http/body/file.rb
+++ b/lib/protocol/http/body/file.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2019-2023, by Samuel Williams.
+# Copyright, 2019-2024, by Samuel Williams.
 
 require_relative 'readable'
 

--- a/lib/protocol/http/body/file.rb
+++ b/lib/protocol/http/body/file.rb
@@ -74,6 +74,8 @@ module Protocol
 				
 				def call(stream)
 					IO.copy_stream(@file, stream, @remaining)
+				ensure
+					stream.close
 				end
 				
 				def join

--- a/lib/protocol/http/body/inflate.rb
+++ b/lib/protocol/http/body/inflate.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2019-2023, by Samuel Williams.
+# Copyright, 2019-2024, by Samuel Williams.
 
 require 'zlib'
 

--- a/lib/protocol/http/body/readable.rb
+++ b/lib/protocol/http/body/readable.rb
@@ -72,13 +72,15 @@ module Protocol
 				def each
 					return to_enum unless block_given?
 					
-					while chunk = self.read
-						yield chunk
+					begin
+						while chunk = self.read
+							yield chunk
+						end
+					rescue => error
+						raise
+					ensure
+						self.close(error)
 					end
-				rescue => error
-					raise
-				ensure
-					self.close(error)
 				end
 				
 				# Read all remaining chunks into a single binary string using `#each`.

--- a/lib/protocol/http/body/readable.rb
+++ b/lib/protocol/http/body/readable.rb
@@ -17,7 +17,11 @@ module Protocol
 			#
 			# If you don't want to read from a stream, and instead want to close it immediately, you can call `close` on the body. If the body is already completely consumed, `close` will do nothing, but if there is still data to be read, it will cause the underlying stream to be reset (and possibly closed).
 			class Readable
-				# Close the stream immediately.
+				# Close the stream immediately. After invoking this method, the stream should be considered closed, and all internal resources should be released.
+				#
+				# If an error occured while handling the output, it can be passed as an argument. This may be propagated to the client, for example the client may be informed that the stream was not fully read correctly.
+				#
+				# Invoking `#read` after `#close` will return `nil`.
 				def close(error = nil)
 				end
 				

--- a/lib/protocol/http/body/readable.rb
+++ b/lib/protocol/http/body/readable.rb
@@ -98,12 +98,14 @@ module Protocol
 					false
 				end
 				
+				# Invoke the body with the given stream.
+				#
+				# The default implementation simply writes each chunk to the stream. If the body is not ready, it will be flushed after each chunk. Closes the stream when finished or if an error occurs.
+				#
 				# Write the body to the given stream.
 				#
-				# In some cases, the stream may also be readable, such as when hijacking an HTTP/1 connection. In that case, it may be acceptable to read and write to the stream directly.
-				#
-				# If the stream is not ready, it will be flushed after each chunk. Closes the stream when finished or if an error occurs.
-				#
+				# @parameter stream [IO | Object] An `IO`-like object that responds to `#read`, `#write` and `#flush`.
+				# @returns [Boolean] Whether the ownership of the stream was transferred.
 				def call(stream)
 					self.each do |chunk|
 						stream.write(chunk)
@@ -113,6 +115,8 @@ module Protocol
 							stream.flush
 						end
 					end
+				ensure
+					stream.close
 				end
 				
 				# Read all remaining chunks into a buffered body and close the underlying input.

--- a/lib/protocol/http/body/stream.rb
+++ b/lib/protocol/http/body/stream.rb
@@ -265,7 +265,13 @@ module Protocol
 				def close_write(error = nil)
 					if output = @output
 						@output = nil
-						output&.close(error)
+						
+						# This is a compatibility hack to work around limitations in protocol-rack and can be removed when external tests are passing without it.
+						if output.method(:close).arity == 1
+							output.close(error)
+						else
+							output.close
+						end
 					end
 				end
 				

--- a/lib/protocol/http/body/stream.rb
+++ b/lib/protocol/http/body/stream.rb
@@ -251,21 +251,21 @@ module Protocol
 				end
 				
 				# Close the input body.
-				def close_read
-					if @input
+				def close_read(error = nil)
+					if input = @input
+						@input = nil
 						@closed_read = true
 						@buffer = nil
 						
-						@input&.close
-						@input = nil
+						input&.close(error)
 					end
 				end
 				
 				# Close the output body.
-				def close_write
-					if @output
-						@output&.close
+				def close_write(error = nil)
+					if output = @output
 						@output = nil
+						output&.close(error)
 					end
 				end
 				

--- a/lib/protocol/http/body/stream.rb
+++ b/lib/protocol/http/body/stream.rb
@@ -21,6 +21,7 @@ module Protocol
 					
 					# Will hold remaining data in `#read`.
 					@buffer = nil
+					
 					@closed = false
 					@closed_read = false
 				end
@@ -257,7 +258,7 @@ module Protocol
 						@closed_read = true
 						@buffer = nil
 						
-						input&.close(error)
+						input.close(error)
 					end
 				end
 				
@@ -266,12 +267,7 @@ module Protocol
 					if output = @output
 						@output = nil
 						
-						# This is a compatibility hack to work around limitations in protocol-rack and can be removed when external tests are passing without it.
-						if output.method(:close).arity == 1
-							output.close(error)
-						else
-							output.close
-						end
+						output.close_write(error)
 					end
 				end
 				

--- a/lib/protocol/http/body/streamable.rb
+++ b/lib/protocol/http/body/streamable.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2022, by Samuel Williams.
+# Copyright, 2019-2024, by Samuel Williams.
 
 require_relative 'readable'
 require_relative 'writable'
@@ -137,7 +137,6 @@ module Protocol
 					
 					# Closing a stream indicates we are no longer interested in reading from it.
 					def close(error = nil)
-						$stderr.puts "Closing input: #{@input.inspect}"
 						if input = @input
 							@input = nil
 							input.close(error)

--- a/lib/protocol/http/body/streamable.rb
+++ b/lib/protocol/http/body/streamable.rb
@@ -17,6 +17,14 @@ module Protocol
 			#
 			# When invoking `call(stream)`, the stream can be read from and written to, and closed. However, the stream is only guaranteed to be open for the duration of the `call(stream)` call. Once the method returns, the stream **should** be closed by the server.
 			module Streamable
+				def self.new(*arguments)
+					if arguments.size == 1
+						RequestBody.new(*arguments)
+					else
+						ResponseBody.new(*arguments)
+					end
+				end
+				
 				# Represents an output wrapper around a stream, that can invoke a fiber when `#read`` is called.
 				#
 				# This behaves a little bit like a generator or lazy enumerator, in that it can be used to generate chunks of data on demand.

--- a/lib/protocol/http/body/streamable.rb
+++ b/lib/protocol/http/body/streamable.rb
@@ -16,35 +16,12 @@ module Protocol
 			# In some cases, it's advantageous to directly read and write to the underlying stream if possible. For example, HTTP/1 upgrade requests, WebSockets, and similar. To handle that case, response bodies can implement `stream?` and return `true`. When `stream?` returns true, the body **should** be consumed by calling `call(stream)`. Server implementations may choose to always invoke `call(stream)` if it's efficient to do so. Bodies that don't support it will fall back to using `#each`.
 			#
 			# When invoking `call(stream)`, the stream can be read from and written to, and closed. However, the stream is only guaranteed to be open for the duration of the `call(stream)` call. Once the method returns, the stream **should** be closed by the server.
-			class Streamable < Readable
-				def self.response(request, &block)
-					self.new(block, request.body)
-				end
-				
-				def self.request(&block)
-					self.new(block)
-				end
-				
-				class Closed < StandardError
-				end
-				
-				def initialize(block, input = nil)
-					@block = block
-					
-					if input
-						@input = input
-						@finishing = true
-					else
-						# If input is nil, it means we are on the client side.
-						@input = Writable.new
-						@finishing = false
-					end
-					
-					@output = nil
-				end
-				
-				attr :block
-				
+			module Streamable
+				# Represents an output wrapper around a stream, that can invoke a fiber when `#read`` is called.
+				#
+				# This behaves a little bit like a generator or lazy enumerator, in that it can be used to generate chunks of data on demand.
+				#
+				# When closing the the output, the block is invoked one last time with `nil` to indicate the end of the stream.
 				class Output
 					def initialize(input, block)
 						stream = Stream.new(input, self)
@@ -100,70 +77,103 @@ module Protocol
 					end
 				end
 				
-				# Invokes the block in a fiber which yields chunks when they are available.
-				def read
-					if @output.nil?
-						if @block.nil?
-							raise "Streaming body has already been consumed!"
+				class Body < Readable
+					def initialize(block, input = nil)
+						@block = block
+						@input = input
+						@output = nil
+					end
+					
+					attr :block
+					
+					def stream?
+						true
+					end
+					
+					# Invokes the block in a fiber which yields chunks when they are available.
+					def read
+						if @output.nil?
+							if @block.nil?
+								raise "Streaming body has already been consumed!"
+							end
+							
+							@output = Output.new(@input, @block)
+							@block = nil
 						end
 						
-						@output = Output.new(@input, @block)
-						@block = nil
+						@output.read
 					end
 					
-					@output.read
+					# Invoke the block with the given stream.
+					#
+					# The block can read and write to the stream, and must close the stream when finishing.
+					def call(stream)
+						if @block.nil?
+							raise "Streaming block has already been consumed!"
+						end
+						
+						block = @block
+						
+						@input = @output = @block = nil
+						
+						# Ownership of the stream is passed into the block, in other words, the block is responsible for closing the stream.
+						block.call(stream)
+					rescue => error
+						# If, for some reason, the block raises an error, we assume it may not have closed the stream, so we close it here:
+						stream.close
+						raise
+					end
+					
+					# Closing a stream indicates we are no longer interested in reading from it.
+					def close(error = nil)
+						if output = @output
+							@output = nil
+							output.close(error)
+						end
+						
+						if input = @input
+							@input = nil
+							input.close(error)
+						end
+					end
 				end
 				
-				# Closing a stream indicates we are no longer interested in reading from it.
-				def close(error = nil)
-					return unless @finishing
-					
-					if output = @output
-						@output = nil
-						output.close(error)
+				# A request body has an extra `stream` method which can be used to stream data into the body, as the response body won't be available until the request has been sent.
+				class RequestBody < Body
+					def initialize(block)
+						super(block, Writable.new)
+						@finishing = false
 					end
 					
-					if input = @input
-						@input = nil
-						input.close(error)
+					def close(error = nil)
+						return unless @finishing
+						super
+					end
+					
+					# Stream the response body into the block's input.
+					def stream(input)
+						input&.each do |chunk|
+							@input&.write(chunk)
+						end
+					rescue => error
+						raise
+					ensure
+						@finishing = true
+						@input&.close
+						
+						self.close(error)
 					end
 				end
 				
-				def stream?
-					true
+				def self.request(&block)
+					RequestBody.new(block)
 				end
 				
-				# Invoke the block with the given stream.
-				#
-				# The block can read and write to the stream, and must close the stream when finishing.
-				def call(stream)
-					if @block.nil?
-						raise "Streaming block has already been consumed!"
-					end
-					
-					block = @block
-					
-					@input = @output = @block = nil
-					
-					# Ownership of the stream is passed into the block, in other words, the block is responsible for closing the stream.
-					block.call(stream)
-				rescue => error
-					# If, for some reason, the block raises an error, we assume it may not have closed the stream, so we close it here:
-					stream.close
-					raise
+				class ResponseBody < Body
 				end
 				
-				def stream(input)
-					input&.each do |chunk|
-						@input&.write(chunk)
-					end
-				rescue => error
-					raise
-				ensure
-					@finishing = true
-					@input&.close
-					
-					self.close(error)
+				def self.response(request, &block)
+					ResponseBody.new(block, request.body)
 				end
 			end
 		end

--- a/lib/protocol/http/body/streamable.rb
+++ b/lib/protocol/http/body/streamable.rb
@@ -47,14 +47,11 @@ module Protocol
 						@fiber = Fiber.new do |from|
 							@from = from
 							block.call(stream)
+						rescue => error
+							# Ignore.
 						ensure
 							@fiber = nil
-							
-							# No more chunks will be generated:
-							if from = @from
-								@from = nil
-								from.transfer(nil)
-							end
+							self.close(error)
 						end
 					end
 					
@@ -182,10 +179,6 @@ module Protocol
 							@input&.write(chunk)
 						end
 						@input&.close_write
-					rescue => error
-						raise
-					ensure
-						self.close(error)
 					end
 				end
 			end

--- a/lib/protocol/http/body/streamable.rb
+++ b/lib/protocol/http/body/streamable.rb
@@ -141,6 +141,8 @@ module Protocol
 						raise "Streaming block has already been consumed!"
 					end
 					
+					block = @block
+					
 					@input = @output = @block = nil
 					
 					# Ownership of the stream is passed into the block, in other words, the block is responsible for closing the stream.
@@ -152,7 +154,7 @@ module Protocol
 				end
 				
 				def stream(input)
-					input.each do |chunk|
+					input&.each do |chunk|
 						@input&.write(chunk)
 					end
 				rescue => error

--- a/test/protocol/http/body/buffered.rb
+++ b/test/protocol/http/body/buffered.rb
@@ -161,6 +161,15 @@ describe Protocol::HTTP::Body::Buffered do
 		end
 	end
 	
+	with "#clear" do
+		it "clears all chunks and resets length" do
+			body.clear
+			expect(body.chunks).to be(:empty?)
+			expect(body.read).to be == nil
+			expect(body.length).to be == 0
+		end
+	end
+	
 	with '#inspect' do
 		it "can be inspected" do
 			expect(body.inspect).to be =~ /\d+ chunks, \d+ bytes/

--- a/test/protocol/http/body/buffered.rb
+++ b/test/protocol/http/body/buffered.rb
@@ -5,10 +5,13 @@
 # Copyright, 2020-2023, by Bruno Sutic.
 
 require 'protocol/http/body/buffered'
+require "protocol/http/body/a_readable_body"
 
 describe Protocol::HTTP::Body::Buffered do
 	let(:source) {["Hello", "World"]}
 	let(:body) {subject.wrap(source)}
+	
+	it_behaves_like Protocol::HTTP::Body::AReadableBody
 	
 	with ".wrap" do
 		with "an instance of Protocol::HTTP::Body::Readable as a source" do

--- a/test/protocol/http/body/deflate.rb
+++ b/test/protocol/http/body/deflate.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2019-2023, by Samuel Williams.
+# Copyright, 2019-2024, by Samuel Williams.
 
 require 'protocol/http/body/buffered'
 require 'protocol/http/body/deflate'
@@ -17,7 +17,6 @@ describe Protocol::HTTP::Body::Deflate do
 	
 	it "should round-trip data" do
 		body.write("Hello World!")
-		body.close
 		
 		expect(decompressed_body.join).to be == "Hello World!"
 	end
@@ -26,7 +25,6 @@ describe Protocol::HTTP::Body::Deflate do
 	
 	it "should round-trip data" do
 		body.write(data)
-		body.close
 		
 		expect(decompressed_body.read).to be == data
 		expect(decompressed_body.read).to be == nil
@@ -39,7 +37,6 @@ describe Protocol::HTTP::Body::Deflate do
 		10.times do
 			body.write("Hello World!")
 		end
-		body.close
 		
 		10.times do
 			expect(decompressed_body.read).to be == "Hello World!"

--- a/test/protocol/http/body/digestable.rb
+++ b/test/protocol/http/body/digestable.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2020-2023, by Samuel Williams.
+# Copyright, 2020-2024, by Samuel Williams.
 
 require 'protocol/http/body/digestable'
 require 'protocol/http/body/buffered'

--- a/test/protocol/http/body/file.rb
+++ b/test/protocol/http/body/file.rb
@@ -9,11 +9,11 @@ describe Protocol::HTTP::Body::File do
 	let(:path) {File.expand_path('file_spec.txt', __dir__)}
 	let(:body) {subject.open(path)}
 	
-	with '#stream?' do
-		it "should be streamable" do
-			expect(body).to be(:stream?)
-		end
-	end
+	# with '#stream?' do
+	# 	it "should be streamable" do
+	# 		expect(body).to be(:stream?)
+	# 	end
+	# end
 	
 	with '#join' do
 		it "should read entire file" do

--- a/test/protocol/http/body/file.rb
+++ b/test/protocol/http/body/file.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2019-2023, by Samuel Williams.
+# Copyright, 2019-2024, by Samuel Williams.
 
 require 'protocol/http/body/file'
 

--- a/test/protocol/http/body/streamable.rb
+++ b/test/protocol/http/body/streamable.rb
@@ -96,6 +96,24 @@ describe Protocol::HTTP::Body::Streamable do
 			expect(stream.string).to be == "HelloWorld"
 		end
 		
+		it "will fail if invoked twice" do
+			stream = StringIO.new
+			body.call(stream)
+			
+			expect do
+				body.call(stream)
+			end.to raise_exception(Protocol::HTTP::Body::Streamable::ConsumedError)
+		end
+		
+		it "will fail if trying to read after streaming" do
+			stream = StringIO.new
+			body.call(stream)
+			
+			expect do
+				body.read
+			end.to raise_exception(Protocol::HTTP::Body::Streamable::ConsumedError)
+		end
+		
 		with "a block that raises an error" do
 			let(:block) do
 				proc do |stream|
@@ -125,7 +143,13 @@ describe Protocol::HTTP::Body::Streamable do
 	with '#close' do
 		it "can close the body" do
 			expect(body.read).to be == "Hello"
+			
 			body.close
+		end
+		
+		it "can raise an error on the block" do
+			expect(body.read).to be == "Hello"
+			body.close(RuntimeError.new("Oh no!"))
 		end
 	end
 	

--- a/test/protocol/http/body/streamable.rb
+++ b/test/protocol/http/body/streamable.rb
@@ -62,7 +62,7 @@ describe Protocol::HTTP::Body::Streamable do
 				
 				expect do
 					@stream.write("!")
-				end.to raise_exception(RuntimeError, message: be =~ /Stream is not being read!/)
+				end.to raise_exception(Protocol::HTTP::Body::Streamable::ClosedError, message: be =~ /Stream is not being read!/)
 			end
 		end
 	end
@@ -149,6 +149,7 @@ describe Protocol::HTTP::Body::Streamable do
 		let(:block) do
 			proc do |stream|
 				while chunk = stream.read_partial
+					$stderr.puts "Got chunk: #{chunk.inspect}"
 					stream.write(chunk)
 				end
 			end
@@ -169,6 +170,13 @@ describe Protocol::HTTP::Body::Streamable do
 			body.call(stream)
 			
 			expect(output.string).to be == "Hello World"
+		end
+		
+		with '#close' do
+			it "can close the body" do
+				expect(body.read).to be == "Hello"
+				body.close
+			end
 		end
 	end
 end

--- a/test/protocol/http/body/streamable.rb
+++ b/test/protocol/http/body/streamable.rb
@@ -103,6 +103,8 @@ describe Protocol::HTTP::Body::Streamable do
 					stream.write("Hello")
 					
 					raise "Oh no... a wild error appeared!"
+				ensure
+					stream.close
 				end
 			end
 			
@@ -115,6 +117,8 @@ describe Protocol::HTTP::Body::Streamable do
 				end.to raise_exception(RuntimeError, message: be =~ /Oh no... a wild error appeared!/)
 				
 				expect(stream.string).to be == "Hello"
+				
+				body.stream(input)
 			end
 		end
 	end

--- a/test/protocol/http/body/streamable.rb
+++ b/test/protocol/http/body/streamable.rb
@@ -14,8 +14,7 @@ describe Protocol::HTTP::Body::Streamable do
 		end
 	end
 	
-	let(:input) {nil}
-	let(:body) {subject.new(block, input)}
+	let(:body) {subject.new(block)}
 	
 	with "#stream?" do
 		it "should be streamable" do
@@ -75,7 +74,7 @@ describe Protocol::HTTP::Body::Streamable do
 			end
 		end
 		
-		let(:body) {subject.new(block, input)}
+		let(:body) {subject.new(block)}
 		
 		it "can close the output body" do
 			expect(body.read).to be == nil
@@ -118,7 +117,7 @@ describe Protocol::HTTP::Body::Streamable do
 				
 				expect(stream.string).to be == "Hello"
 				
-				body.stream(input)
+				body.stream(nil)
 			end
 		end
 	end
@@ -154,6 +153,8 @@ describe Protocol::HTTP::Body::Streamable do
 				end
 			end
 		end
+		
+		let(:body) {subject.new(block, input)}
 		
 		it "can read from input" do
 			expect(body.read).to be == "Hello"

--- a/test/protocol/http/body/streamable.rb
+++ b/test/protocol/http/body/streamable.rb
@@ -133,9 +133,6 @@ describe Protocol::HTTP::Body::Streamable do
 				end.to raise_exception(RuntimeError, message: be =~ /Oh no... a wild error appeared!/)
 				
 				expect(stream.string).to be == "Hello"
-				
-				body.stream(nil)
-				body.close
 			end
 		end
 	end

--- a/test/protocol/http/body/streamable.rb
+++ b/test/protocol/http/body/streamable.rb
@@ -68,6 +68,20 @@ describe Protocol::HTTP::Body::Streamable do
 		end
 	end
 	
+	with '#close_write' do
+		let(:block) do
+			proc do |stream|
+				stream.close_write
+			end
+		end
+		
+		let(:body) {subject.new(block, input)}
+		
+		it "can close the output body" do
+			expect(body.read).to be == nil
+		end
+	end
+	
 	with '#each' do
 		it "can read the body" do
 			chunks = []

--- a/test/protocol/http/body/streamable.rb
+++ b/test/protocol/http/body/streamable.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2022, by Samuel Williams.
+# Copyright, 2024, by Samuel Williams.
 
 require 'protocol/http/body/streamable'
 
@@ -149,7 +149,6 @@ describe Protocol::HTTP::Body::Streamable do
 		let(:block) do
 			proc do |stream|
 				while chunk = stream.read_partial
-					$stderr.puts "Got chunk: #{chunk.inspect}"
 					stream.write(chunk)
 				end
 			end

--- a/test/protocol/http/body/writable.rb
+++ b/test/protocol/http/body/writable.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2018-2023, by Samuel Williams.
+# Copyright, 2024, by Samuel Williams.
 
 require 'protocol/http/body/writable'
 require 'protocol/http/body/deflate'
+require 'protocol/http/body/a_writable_body'
 
 describe Protocol::HTTP::Body::Writable do
 	let(:body) {subject.new}
+	
+	it_behaves_like Protocol::HTTP::Body::AWritableBody
 	
 	with "#length" do
 		it "should be unspecified by default" do


### PR DESCRIPTION
Bi-directional streaming is important for things like WebSockets, especially considering that we want to keep the WebSocket client and server as efficient as possible.

Streamable bodies use the `stream? -> true` escape hatch which reduces the complexity of supporting bi-directional streaming clients and servers.

I have a strong desire to remove this feature as the complexity is only slightly outweighed by the benefits. As an interface, it's strictly worse IMHO. In essence, the streaming interface has distinctly different requirements on the client and server side (see `#stream(input)` on the client side).

As an alternative, maybe we can remove "Streamable" as a concept and instead introduce some kind of `hijack!` mechanism for the request and response side of the connection handling. This mechanism only applies to HTTP/1 in general.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.
- Breaking change.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
