### PR TITLE
Use `Fiber.schedule` in Streamable.

### DIFF
--- a/examples/streaming/gems.locked
+++ b/examples/streaming/gems.locked
@@ -27,13 +27,20 @@ GEM
       fiber-annotation
       fiber-local (~> 1.1)
       json
+    debug (1.9.2)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     fiber-annotation (0.2.0)
     fiber-local (1.1.0)
       fiber-storage
     fiber-storage (1.0.0)
+    io-console (0.7.2)
     io-endpoint (0.13.1)
     io-event (1.6.5)
     io-stream (0.4.0)
+    irb (1.14.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.7.2)
     metrics (0.10.2)
     protocol-hpack (1.5.0)
@@ -42,6 +49,13 @@ GEM
     protocol-http2 (0.18.0)
       protocol-hpack (~> 1.4)
       protocol-http (~> 0.18)
+    psych (5.1.2)
+      stringio
+    rdoc (6.7.0)
+      psych (>= 4.0.0)
+    reline (0.5.10)
+      io-console (~> 0.5)
+    stringio (3.1.1)
     traces (0.13.1)
 
 PLATFORMS
@@ -51,6 +65,7 @@ PLATFORMS
 DEPENDENCIES
   async
   async-http
+  debug
   protocol-http!
 
 BUNDLED WITH

--- a/examples/streaming/gems.locked
+++ b/examples/streaming/gems.locked
@@ -1,4 +1,17 @@
 PATH
+  remote: ../../../async-http
+  specs:
+    async-http (0.75.0)
+      async (>= 2.10.2)
+      async-pool (~> 0.7)
+      io-endpoint (~> 0.11)
+      io-stream (~> 0.4)
+      protocol-http (~> 0.33)
+      protocol-http1 (~> 0.20)
+      protocol-http2 (~> 0.18)
+      traces (>= 0.10)
+
+PATH
   remote: ../..
   specs:
     protocol-http (0.33.0)
@@ -10,15 +23,6 @@ GEM
       console (~> 1.26)
       fiber-annotation
       io-event (~> 1.6, >= 1.6.5)
-    async-http (0.75.0)
-      async (>= 2.10.2)
-      async-pool (~> 0.7)
-      io-endpoint (~> 0.11)
-      io-stream (~> 0.4)
-      protocol-http (~> 0.30)
-      protocol-http1 (~> 0.20)
-      protocol-http2 (~> 0.18)
-      traces (>= 0.10)
     async-pool (0.8.1)
       async (>= 1.25)
       metrics
@@ -64,7 +68,7 @@ PLATFORMS
 
 DEPENDENCIES
   async
-  async-http
+  async-http!
   debug
   protocol-http!
 

--- a/examples/streaming/gems.rb
+++ b/examples/streaming/gems.rb
@@ -8,3 +8,5 @@ source "https://rubygems.org"
 gem "async"
 gem "async-http"
 gem "protocol-http", path: "../../"
+
+gem "debug"

--- a/examples/streaming/gems.rb
+++ b/examples/streaming/gems.rb
@@ -6,7 +6,7 @@
 source "https://rubygems.org"
 
 gem "async"
-gem "async-http"
+gem "async-http", path: "../../../async-http"
 gem "protocol-http", path: "../../"
 
 gem "debug"

--- a/examples/streaming/simple.rb
+++ b/examples/streaming/simple.rb
@@ -18,13 +18,8 @@ endpoint = Async::HTTP::Endpoint.parse('http://localhost:3000')
 Async do
 	server = Async::HTTP::Server.for(endpoint) do |request|
 		output = Protocol::HTTP::Body::Streamable.response(request) do |stream|
-			# Simple echo server:
-			while chunk = stream.readpartial(1024)
-				$stderr.puts "Server chunk: #{chunk.inspect}"
-				stream.write(chunk)
-				$stderr.puts "Server waiting for next chunk..."
-			end
-			$stderr.puts "Server done reading request."
+			$stderr.puts "Server sending text..."
+			stream.write("Hello from server!")
 		rescue EOFError
 			$stderr.puts "Server EOF."
 			# Ignore EOF errors.
@@ -41,24 +36,14 @@ Async do
 	client = Async::HTTP::Client.new(endpoint)
 	
 	streamable = Protocol::HTTP::Body::Streamable.request do |stream|
-		stream.write("Hello, ")
-		stream.write("World!")
-		
-		$stderr.puts "Client closing write..."
-		stream.close_write
-		
-		$stderr.puts "Client reading response..."
-		
 		while chunk = stream.readpartial(1024)
 			$stderr.puts "Client chunk: #{chunk.inspect}"
-			puts chunk
 		end
-		$stderr.puts "Client done reading response."
 	rescue EOFError
 		$stderr.puts "Client EOF."
 		# Ignore EOF errors.
 	ensure
-		$stderr.puts "Client closing stream: #{$!}"
+		$stderr.puts "Client closing stream."
 		stream.close
 	end
 	

--- a/gems.rb
+++ b/gems.rb
@@ -25,3 +25,5 @@ group :test do
 	gem "bake-test"
 	gem "bake-test-external"
 end
+
+gem "debug", ">= 1.0.0"

--- a/gems.rb
+++ b/gems.rb
@@ -28,4 +28,4 @@ group :test do
 	gem "bake-test-external"
 end
 
-gem "async-http", path: "../async-http"
+# gem "async-http", path: "../async-http"

--- a/gems.rb
+++ b/gems.rb
@@ -26,4 +26,4 @@ group :test do
 	gem "bake-test-external"
 end
 
-gem "debug", ">= 1.0.0"
+gem "async-http", path: "../async-http"

--- a/gems.rb
+++ b/gems.rb
@@ -22,6 +22,8 @@ group :test do
 	gem "decode"
 	gem "rubocop"
 	
+	gem "sus-fixtures-async"
+	
 	gem "bake-test"
 	gem "bake-test-external"
 end

--- a/lib/protocol/http/body/streamable.rb
+++ b/lib/protocol/http/body/streamable.rb
@@ -47,7 +47,6 @@ module Protocol
 					def schedule
 						@fiber ||= Fiber.schedule do
 							@block.call(@stream)
-							
 						end
 					end
 					
@@ -70,12 +69,6 @@ module Protocol
 						@input = input
 						@output = nil
 					end
-					
-					attr :block
-					
-					attr :input
-					
-					attr :output
 					
 					def stream?
 						true

--- a/lib/protocol/http/body/streamable.rb
+++ b/lib/protocol/http/body/streamable.rb
@@ -17,85 +17,6 @@ module Protocol
 			#
 			# When invoking `call(stream)`, the stream can be read from and written to, and closed. However, the stream is only guaranteed to be open for the duration of the `call(stream)` call. Once the method returns, the stream **should** be closed by the server.
 			module Streamable
-				# Raised when an operation is attempted on a closed stream.
-				class ClosedError < StandardError
-				end
-				
-				# Raised when a streaming body is consumed more than once.
-				class ConsumedError < StandardError
-				end
-				
-				# Single value queue that can be used to communicate between fibers.
-				class Queue
-					def self.consumer
-						self.new(Fiber.current, nil)
-					end
-					
-					def self.generator(&block)
-						self.new(Fiber.new(&block), Fiber.current)
-					end
-					
-					def initialize(generator, consumer)
-						@generator = generator
-						@consumer = consumer
-						@closed = false
-					end
-					
-					# The generator fiber can push values into the queue.
-					def push(value)
-						raise ClosedError, "Queue is closed!" if @closed
-						
-						if consumer = @consumer
-							@consumer = nil
-							@generator = Fiber.current
-							
-							consumer.transfer(value)
-						else
-							raise ClosedError, "Queue is not being popped!"
-						end
-					end
-					
-					# The consumer fiber can pop values from the queue.
-					def pop
-						return nil if @closed
-						
-						if generator = @generator
-							@generator = nil
-							@consumer = Fiber.current
-							
-							return generator.transfer
-						else
-							raise ClosedError, "Queue is not being pushed!"
-						end
-					end
-					
-					def close(error = nil)
-						@closed = true
-						
-						if consumer = @consumer
-							@consumer = nil
-							
-							if consumer.alive?
-								@generator = Fiber.current
-								if error
-									consumer.raise(error)
-								else
-									consumer.transfer(nil)
-								end
-							end
-						elsif generator = @generator
-							@generator = nil
-							@consumer = Fiber.current
-							
-							if error
-								generator.raise(error)
-							else
-								generator.transfer(nil)
-							end
-						end
-					end
-				end
-				
 				def self.new(*arguments)
 					if arguments.size == 1
 						DeferredBody.new(*arguments)
@@ -112,73 +33,35 @@ module Protocol
 					Body.new(block, request.body)
 				end
 				
-				class Input
-					def initialize
-						@queue = Queue.consumer
+				class Output
+					def self.schedule(input, block)
+						self.new(input, block).tap(&:schedule)
+					end
+					
+					def initialize(input, block)
+						@output = Writable.new
+						@stream = Stream.new(input, @output)
+						@block = block
+					end
+					
+					def schedule
+						@fiber ||= Fiber.schedule do
+							@block.call(@stream)
+							
+						end
 					end
 					
 					def read
-						@queue.pop
-					end
-					
-					def write(chunk)
-						@queue.push(chunk)
-					end
-					
-					def close_write(error = nil)
-						close(error)
+						@output.read
 					end
 					
 					def close(error = nil)
-						@queue.close(error)
-					end
-					
-					def stream(body)
-						body&.each do |chunk|
-							$stderr.puts "Input stream chunk: #{chunk.inspect}"
-							self.write(chunk)
-						end
-					ensure
-						$stderr.puts "Input stream closed: #{$!}"
-						self.close_write
+						@output.close_write(error)
 					end
 				end
 				
-				# Represents an output wrapper around a stream, that can invoke a fiber when `#read`` is called.
-				#
-				# This behaves a little bit like a generator or lazy enumerator, in that it can be used to generate chunks of data on demand.
-				#
-				# When closing the the output, the block is invoked one last time with `nil` to indicate the end of the stream.
-				class Output
-					def initialize(input, block)
-						stream = Stream.new(input, self)
-						
-						@queue = Queue.generator do
-							block.call(stream)
-						end
-					end
-					
-					attr :stream
-					
-					# Generator of the output can write chunks.
-					def write(chunk)
-						@queue.push(chunk)
-					end
-					
-					# Indicates that no further output will be generated.
-					def close_write(error = nil)
-						close(error)
-					end
-					
-					# Can be invoked by the block to close the stream. Closing the output means that no more chunks will be generated.
-					def close(error = nil)
-						@queue.close(error)
-					end
-					
-					# Consumer of the output can read chunks.
-					def read
-						@queue.pop
-					end
+				# Raised when a streaming body is consumed more than once.
+				class ConsumedError < StandardError
 				end
 				
 				class Body < Readable
@@ -189,6 +72,10 @@ module Protocol
 					end
 					
 					attr :block
+					
+					attr :input
+					
+					attr :output
 					
 					def stream?
 						true
@@ -202,7 +89,7 @@ module Protocol
 								raise ConsumedError, "Streaming body has already been consumed!"
 							end
 							
-							@output = Output.new(@input, @block)
+							@output = Output.schedule(@input, @block)
 							@block = nil
 						end
 						
@@ -231,14 +118,12 @@ module Protocol
 					
 					# Closing a stream indicates we are no longer interested in reading from it.
 					def close(error = nil)
-						$stderr.puts "Closing output #{@output}..."
 						if output = @output
 							@output = nil
 							# Closing the output here may take some time, as it may need to finish handling the stream:
 							output.close(error)
 						end
 						
-						$stderr.puts "Closing input #{@input}..."
 						if input = @input
 							@input = nil
 							input.close(error)
@@ -249,29 +134,25 @@ module Protocol
 				# A deferred body has an extra `stream` method which can be used to stream data into the body, as the response body won't be available until the request has been sent.
 				class DeferredBody < Body
 					def initialize(block)
-						super(block, Input.new)
+						super(block, Writable.new)
 					end
 					
-					# Closing a stream indicates we are no longer interested in reading from it.
+					# Closing a stream indicates we are no longer interested in reading from it, but in this case that does not mean that the output block is finished generating data.
 					def close(error = nil)
+						if error
+							super
+						end
 					end
 					
 					# Stream the response body into the block's input.
 					def stream(body)
-						@input.stream(body)
-						
-						$stderr.puts "Closing output #{@output}..."
-						if output = @output
-							@output = nil
-							# Closing the output here may take some time, as it may need to finish handling the stream:
-							output.close(error)
+						body&.each do |chunk|
+							@input.write(chunk)
 						end
-						
-						$stderr.puts "Closing input #{@input}..."
-						if input = @input
-							@input = nil
-							input.close(error)
-						end
+					rescue => error
+						raise
+					ensure
+						@input.close_write(error)
 					end
 				end
 			end

--- a/test/protocol/http/body/streamable.rb
+++ b/test/protocol/http/body/streamable.rb
@@ -25,12 +25,6 @@ describe Protocol::HTTP::Body::Streamable do
 		end
 	end
 	
-	with '#block' do
-		it "should wrap block" do
-			expect(body.block).to be == block
-		end
-	end
-	
 	with '#read' do
 		it "can read the body" do
 			expect(body.read).to be == "Hello"


### PR DESCRIPTION
I'm unhappy that this was the only way to effectively implement this functionality, but I could not see any easy way to implement asynchronous flow control which is what is needed if invoking `#each` on a Streamable. The alternative is to simply fail. I tried implementing a bi-directional queue for handling input and output but it was extremely difficult to make it make sense in the context of both client and server behaviour, across HTTP/1 and HTTP/2+.

Therefore, using `Fiber.schedule` makes sense. However, I'm unhappy because it specifically introduces asynchronicity into a library which is supposed to be strictly sequential. It turns out implementing it sequentially is not worth the complexity.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
