### PR TITLE
Introduce `Body#discard` for efficiently ignoring body.

### DIFF
--- a/lib/protocol/http/body/buffered.rb
+++ b/lib/protocol/http/body/buffered.rb
@@ -90,6 +90,10 @@ module Protocol
 					end
 				end
 				
+				def discard
+					clear
+				end
+				
 				def write(chunk)
 					@chunks << chunk
 				end

--- a/lib/protocol/http/body/buffered.rb
+++ b/lib/protocol/http/body/buffered.rb
@@ -59,6 +59,8 @@ module Protocol
 				# Ensure that future reads return nil, but allow for rewinding.
 				def close(error = nil)
 					@index = @chunks.length
+					
+					return nil
 				end
 				
 				def clear
@@ -91,7 +93,7 @@ module Protocol
 				end
 				
 				def discard
-					clear
+					self.close
 				end
 				
 				def write(chunk)

--- a/lib/protocol/http/body/readable.rb
+++ b/lib/protocol/http/body/readable.rb
@@ -133,9 +133,13 @@ module Protocol
 					Buffered.read(self)
 				end
 				
+				# Discard the body as efficiently as possible.
+				#
+				# The default implementation simply reads all chunks until the body is empty.
+				#
+				# Useful for discarding the body when it is not needed, but preserving the underlying connection.
 				def discard
 					while chunk = self.read
-						chunk.clear
 					end
 				end
 				

--- a/lib/protocol/http/body/readable.rb
+++ b/lib/protocol/http/body/readable.rb
@@ -133,6 +133,12 @@ module Protocol
 					Buffered.read(self)
 				end
 				
+				def discard
+					while chunk = self.read
+						chunk.clear
+					end
+				end
+				
 				def as_json(...)
 					{
 						class: self.class.name,

--- a/lib/protocol/http/body/reader.rb
+++ b/lib/protocol/http/body/reader.rb
@@ -40,6 +40,14 @@ module Protocol
 					end
 				end
 				
+				# Discard the body as efficiently as possible.
+				def discard
+					if body = @body
+						@body = nil
+						body.discard
+					end
+				end
+				
 				# Buffer the entire request/response body.
 				# @returns [Reader] itself.
 				def buffered!

--- a/lib/protocol/http/body/wrapper.rb
+++ b/lib/protocol/http/body/wrapper.rb
@@ -59,6 +59,10 @@ module Protocol
 					@body.read
 				end
 				
+				def discard
+					@body.discard
+				end
+				
 				def as_json(...)
 					{
 						class: self.class.name,

--- a/test/protocol/http/body/buffered.rb
+++ b/test/protocol/http/body/buffered.rb
@@ -175,4 +175,12 @@ describe Protocol::HTTP::Body::Buffered do
 			expect(body.inspect).to be =~ /\d+ chunks, \d+ bytes/
 		end
 	end
+	
+	with "#discard" do
+		it "closes the body" do
+			expect(body).to receive(:close)
+			
+			expect(body.discard).to be == nil
+		end
+	end
 end

--- a/test/protocol/http/body/readable.rb
+++ b/test/protocol/http/body/readable.rb
@@ -58,6 +58,13 @@ describe Protocol::HTTP::Body::Readable do
 		end
 	end
 	
+	with "#discard" do
+		it "should read all chunks" do
+			expect(body).to receive(:read).and_return(nil)
+			expect(body.discard).to be_nil
+		end
+	end
+	
 	with "#as_json" do
 		it "generates a JSON representation" do
 			expect(body.as_json).to have_keys(

--- a/test/protocol/http/body/reader.rb
+++ b/test/protocol/http/body/reader.rb
@@ -29,6 +29,13 @@ describe Protocol::HTTP::Body::Reader do
 		end
 	end
 	
+	with "#discard" do
+		it 'discards the body' do
+			expect(body).to receive(:discard)
+			expect(reader.discard).to be_nil
+		end
+	end
+	
 	with '#buffered!' do
 		it 'buffers the body' do
 			expect(reader.buffered!).to be_equal(reader)

--- a/test/protocol/http/body/wrapper.rb
+++ b/test/protocol/http/body/wrapper.rb
@@ -104,4 +104,11 @@ describe Protocol::HTTP::Body::Wrapper do
 			body.call(stream)
 		end
 	end
+	
+	with "#discard" do
+		it "should proxy discard" do
+			expect(source).to receive(:discard).and_return(nil)
+			expect(body.discard).to be_nil
+		end
+	end
 end


### PR DESCRIPTION
In some cases, it is desirable to quickly throw away a body without stalling a connection. In the case of HTTP/1, e.g. `connection: close` the only option is to close the underlying stream. In HTTP/2, there are other options.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
