### PR TITLE
Fix: undefined method split for an instance of Integer (NoMethodError)

### DIFF
--- a/lib/protocol/http/header/split.rb
+++ b/lib/protocol/http/header/split.rb
@@ -11,8 +11,10 @@ module Protocol
 				COMMA = /\s*,\s*/
 				
 				def initialize(value)
-					if value
+					if value && value.respond_to?(:split)
 						super(value.split(COMMA))
+					elsif value
+						super([value])
 					else
 						super([])
 					end


### PR DESCRIPTION
I'm planing migrate from Puma to Falcon and during my tests I have found this issue.

Error:
```
    1m     warn: Async::Task: Reading HTTP/1.1 requests for Async::HTTP::Protocol::HTTP1::Server. [oid=0x456dc] [ec=0x449a8] [pid=9856] [2024-09-16 09:58:11 -0300]
               | Task may have ended with unhandled exception.
               |   NoMethodError: undefined method `split' for an instance of Integer (NoMethodError)
               |   
               |                                                super(value.split(COMMA))
               |                                                           ^^^^^^
               |   → /Users/wagner/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/protocol-http-0.35.0/lib/protocol/http/header/split.rb:16 in `initialize'
               |     /Users/wagner/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/protocol-http-0.35.0/lib/protocol/http/headers.rb:281 in `new'
               |     /Users/wagner/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/protocol-http-0.35.0/lib/protocol/http/headers.rb:281 in `merge_into'
               |     /Users/wagner/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/protocol-http-0.35.0/lib/protocol/http/headers.rb:296 in `block in to_h'
               |     /Users/wagner/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/protocol-http-0.35.0/lib/protocol/http/headers.rb:295 in `each'
               |     /Users/wagner/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/protocol-http-0.35.0/lib/protocol/http/headers.rb:295 in `inject'
               |     /Users/wagner/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/protocol-http-0.35.0/lib/protocol/http/headers.rb:295 in `to_h'
               |     /Users/wagner/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/protocol-http-0.35.0/lib/protocol/http/headers.rb:290 in `[]'
               |     /Users/wagner/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/protocol-http-0.35.0/lib/protocol/http/content_encoding.rb:32 in `call'
               |     /Users/wagner/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/protocol-http-0.35.0/lib/protocol/http/middleware.rb:43 in `call'
               |     /Users/wagner/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/async-http-0.76.0/lib/async/http/server.rb:61 in `block in accept'
               |     /Users/wagner/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/async-http-0.76.0/lib/async/http/protocol/http1/server.rb:49 in `each'
               |     /Users/wagner/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/async-http-0.76.0/lib/async/http/server.rb:50 in `accept'
               |     /Users/wagner/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/io-endpoint-0.13.1/lib/io/endpoint/wrapper.rb:182 in `block (2 levels) in accept'
               |     /Users/wagner/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/async-2.17.0/lib/async/task.rb:197 in `block in run'
               |     /Users/wagner/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/async-2.17.0/lib/async/task.rb:422 in `block in schedule'
```

I don't know if was expected to `Protocol::HTTP::Header::Split` be able to handle Integers but I guess is safe to check if value can respond_to `split`. This solved the issue.

## Types of Changes
- Bug fix.

## Contribution
- [ ] I added tests for my changes.
- [X] I tested my changes locally.
- [X] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
