### PR TITLE
Invoke close on input stream when input is finished.

### DIFF
--- a/lib/protocol/http/body/stream.rb
+++ b/lib/protocol/http/body/stream.rb
@@ -295,7 +295,14 @@ module Protocol
 				
 				def read_next
 					if @input
-						return @input.read
+						# User's may forget to call #close...
+						if chunk = @input.read
+							return chunk
+						else
+							# So if we are at the end of the stream, we close it automatically:
+							@input.close
+							@input = nil
+						end
 					elsif @closed_read
 						raise IOError, "Stream is not readable, input has been closed!"
 					end

--- a/test/protocol/http/body/streamable.rb
+++ b/test/protocol/http/body/streamable.rb
@@ -175,9 +175,10 @@ describe Protocol::HTTP::Body::Streamable do
 		
 		with "#close" do
 			it "can close the body" do
-				expect(input).not.to receive(:close)
+				expect(input).to receive(:close)
 				
 				expect(body.read).to be == "Hello"
+				
 				body.close
 			end
 		end


### PR DESCRIPTION
After reviewing <https://github.com/socketry/async-http/issues/183>, I think we should automatically close the input when input is read completely.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
