### PR TITLE
Fix unused variable warning.

### DIFF
--- a/lib/protocol/http/body/stream.rb
+++ b/lib/protocol/http/body/stream.rb
@@ -263,7 +263,7 @@ module Protocol
 								buffer = @buffer
 								@buffer = nil
 								
-								return @buffer
+								return buffer
 							end
 						end
 						


### PR DESCRIPTION
Looking at the code, it looks like it caught an actual bug.

```
protocol-http-0.47.1/lib/protocol/http/body/stream.rb:263: warning: assigned but unused variable - buffer
```
