### PR TITLE
Force string for header value for default policy

### DIFF
--- a/lib/protocol/http/header/split.rb
+++ b/lib/protocol/http/header/split.rb
@@ -17,10 +17,13 @@ module Protocol
 				#
 				# @parameter value [String | Nil] the raw header value containing multiple entries separated by commas, or `nil` for an empty header.
 				def initialize(value = nil)
-					if value
+					case value
+					when String
 						super(value.split(COMMA))
+					when nil
+						super()	
 					else
-						super()
+						super([value.to_s])	
 					end
 				end
 				

--- a/test/protocol/http/headers.rb
+++ b/test/protocol/http/headers.rb
@@ -13,7 +13,8 @@ describe Protocol::HTTP::Headers do
 			["Set-Cookie", "hello=world"],
 			["Accept", "*/*"],
 			["set-cookie", "foo=bar"],
-			["connection", "Keep-Alive"]
+			["connection", "Keep-Alive"],
+			["X-Foo", 1]
 		]
 	end
 	
@@ -29,7 +30,7 @@ describe Protocol::HTTP::Headers do
 	
 	with "#keys" do
 		it "should return keys" do
-			expect(headers.keys).to be == ["content-type", "set-cookie", "accept", "connection"]
+			expect(headers.keys).to be == ["content-type", "set-cookie", "accept", "connection", "x-foo"]
 		end
 	end
 	
@@ -55,7 +56,8 @@ describe Protocol::HTTP::Headers do
 				"content-type" => "text/plain",
 				"set-cookie" => ["hello=world", "foo=bar", "goodbye=world"],
 				"accept" => ["*/*"],
-				"connection" => ["keep-alive"]
+				"connection" => ["keep-alive"],
+				"x-foo" => ["1"]
 			}
 		end
 	end


### PR DESCRIPTION
## Types of Changes
Fixes #81 by casting any non-nil && non-string value to a string. Since application code may set any header value to any object, forcing a string here makes sense.

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
