### PR TITLE
Add `Headers#to_a` method

### DIFF
--- a/lib/protocol/http/headers.rb
+++ b/lib/protocol/http/headers.rb
@@ -108,6 +108,11 @@ module Protocol
 			# @attribute [Array] An array of `[key, value]` pairs.
 			attr :fields
 			
+			# @returns [Array] The fields of the headers.
+			def to_a
+				@fields
+			end
+			
 			# @returns [Boolean] Whether there are any trailers.
 			def trailer?
 				@tail != nil

--- a/test/protocol/http/headers.rb
+++ b/test/protocol/http/headers.rb
@@ -148,6 +148,20 @@ describe Protocol::HTTP::Headers do
 		end
 	end
 	
+	with "#to_a" do
+		it "should return the fields array" do
+			expect(headers.to_a).to be == fields
+		end
+		
+		it "should return the same object as fields" do
+			expect(headers.to_a).to be_equal(headers.fields)
+		end
+		
+		it "should return an array" do
+			expect(headers.to_a).to be_a(Array)
+		end
+	end
+	
 	with "#to_h" do
 		it "should generate array values for duplicate keys" do
 			expect(headers.to_h["set-cookie"]).to be == ["hello=world", "foo=bar"]


### PR DESCRIPTION
- Adds Headers#to_a method that returns the fields array
- Provides compatibility with standard Ruby array conversion pattern
- Includes comprehensive tests for the new method

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
