### PR TITLE
Add support for constructing headers with tail marker.

### DIFF
--- a/lib/protocol/http/headers.rb
+++ b/lib/protocol/http/headers.rb
@@ -64,13 +64,15 @@ module Protocol
 			# Initialize the headers with the specified fields.
 			#
 			# @parameter fields [Array] An array of `[key, value]` pairs.
-			# @parameter indexed [Hash] A hash table of normalized headers, if available.
-			def initialize(fields = [], indexed = nil)
+			# @parameter tail [Integer | Nil] The index of the trailer start in the @fields array.
+			def initialize(fields = [], tail = nil, indexed: nil)
 				@fields = fields
-				@indexed = indexed
 				
-				# Marks where trailer start in the @fields array.
-				@tail = nil
+				# Marks where trailer start in the @fields array:
+				@tail = tail
+				
+				# The cached index of headers:
+				@indexed = nil
 			end
 			
 			# Initialize a copy of the headers.
@@ -86,8 +88,8 @@ module Protocol
 			# Clear all headers.
 			def clear
 				@fields.clear
-				@indexed = nil
 				@tail = nil
+				@indexed = nil
 			end
 			
 			# Flatten trailer into the headers, in-place.
@@ -107,6 +109,9 @@ module Protocol
 			
 			# @attribute [Array] An array of `[key, value]` pairs.
 			attr :fields
+			
+			# @attribute [Integer | Nil] The index where trailers begin.
+			attr :tail
 			
 			# @returns [Array] The fields of the headers.
 			def to_a

--- a/releases.md
+++ b/releases.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
   - Add `Protocol::HTTP::Headers#to_a` method that returns the fields array, providing compatibility with standard Ruby array conversion pattern.
+  - Expose `tail` in `Headers.new` so that trailers can be accurately reproduced.
 
 ## v0.51.0
 


### PR DESCRIPTION
Headers has fields and tail as key data, the `@indexed` instance variable is just a cache (and is always going to be optional).

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Breaking change.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
