### PR TITLE
Adjust parentheses after `<<` method name.

### DIFF
--- a/lib/protocol/http/body/stream.rb
+++ b/lib/protocol/http/body/stream.rb
@@ -315,7 +315,7 @@ module Protocol
 				end
 				
 				# Write data to the stream using {write}.
-				def <<(buffer)
+				def << buffer
 					write(buffer)
 				end
 				

--- a/lib/protocol/http/header/accept.rb
+++ b/lib/protocol/http/header/accept.rb
@@ -81,7 +81,7 @@ module Protocol
 				# The input string is split into distinct entries and appended to the array.
 				#
 				# @parameter value [String] the value or values to add, separated by commas.
-				def << (value)
+				def << value
 					self.concat(value.scan(SEPARATOR).map(&:strip))
 				end
 				


### PR DESCRIPTION
While using Ruby 3.3.9, I saw the following warning:
```
% bundle exec rake test
…/protocol-http-0.53.0/lib/protocol/http/header/accept.rb:84:
warning: parentheses after method name is interpreted as an argument list, not a decomposed argument
```

### Types of Changes

- Maintenance.

### Contribution

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).