### PR TITLE
Guard Peer.for against IO objects without remote_address

### DIFF
--- a/lib/protocol/http/peer.rb
+++ b/lib/protocol/http/peer.rb
@@ -11,9 +11,13 @@ module Protocol
 			#
 			# @returns [Peer | Nil] The peer object, or nil if the remote address is not available.
 			def self.for(io)
-				if address = io.remote_address
-					return new(address)
+				if io.respond_to?(:remote_address)
+					if address = io.remote_address
+						return new(address)
+					end
 				end
+				
+				return nil
 			end
 			
 			# Initialize the peer with the given address.

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - `Protocol::HTTP::Peer.for` now returns `nil` for IO objects that do not respond to `remote_address`, rather than raising `NoMethodError`.
+
 ## v0.62.1
 
   - Fix handling of `Stream#read(0)`, it must return a mutable string (or clear the given buffer).

--- a/test/protocol/http/peer.rb
+++ b/test/protocol/http/peer.rb
@@ -17,4 +17,10 @@ describe Protocol::HTTP::Peer do
 			address: be_equal(address),
 		)
 	end
+	
+	it "returns nil for IO that does not support remote_address" do
+		io = StringIO.new
+		
+		expect(Protocol::HTTP::Peer.for(io)).to be_nil
+	end
 end


### PR DESCRIPTION
## Summary

- `Protocol::HTTP::Peer.for` now checks `respond_to?(:remote_address)` before calling the method, so plain `IO` objects (such as stdin/stdout used by HTTY) return `nil` rather than raising `NoMethodError`.
- Added a test covering the case where the IO object does not support `remote_address`.
- Added an unreleased release note.

## Test plan

- [ ] Run `bake test` and confirm all tests pass.

Made with [Cursor](https://cursor.com)