### PR TITLE
Add QUERY HTTP method

### DIFF
--- a/lib/protocol/http/methods.rb
+++ b/lib/protocol/http/methods.rb
@@ -51,7 +51,7 @@ module Protocol
 			# The PATCH method applies partial modifications to a resource.
 			PATCH = "PATCH"
 			
-			# The QUERY method requests a server-side query of the target resource.
+			# The QUERY method performs a safe, idempotent query using a request body.
 			QUERY = "QUERY"
 			
 			# Check if the given name is a valid HTTP method, according to this module.

--- a/lib/protocol/http/methods.rb
+++ b/lib/protocol/http/methods.rb
@@ -51,7 +51,7 @@ module Protocol
 			# The PATCH method applies partial modifications to a resource.
 			PATCH = "PATCH"
 			
-			# The QUERY method performs a safe, idempotent query using a request body.
+			# The QUERY method performs a read-only, idempotent query using a request body.
 			QUERY = "QUERY"
 			
 			# Check if the given name is a valid HTTP method, according to this module.

--- a/lib/protocol/http/methods.rb
+++ b/lib/protocol/http/methods.rb
@@ -18,6 +18,7 @@ module Protocol
 		# | OPTIONS     | Optional     | Yes           | Yes  | Yes        | No        |
 		# | TRACE       | No           | Yes           | Yes  | Yes        | No        |
 		# | PATCH       | Yes          | Yes           | No   | No         | No        |
+		# | QUERY       | Yes          | Yes           | Yes  | Yes        | Yes       |
 		#
 		# These methods are defined in this module using lower case names. They are for convenience only and you should not overload those methods.
 		#
@@ -49,6 +50,9 @@ module Protocol
 			
 			# The PATCH method applies partial modifications to a resource.
 			PATCH = "PATCH"
+			
+			# The QUERY method requests a server-side query of the target resource.
+			QUERY = "QUERY"
 			
 			# Check if the given name is a valid HTTP method, according to this module.
 			#

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Add support for the HTTP `QUERY` method.
+
 ## v0.62.1
 
   - Fix handling of `Stream#read(0)`, it must return a mutable string (or clear the given buffer).

--- a/test/protocol/http/methods.rb
+++ b/test/protocol/http/methods.rb
@@ -33,9 +33,10 @@ describe Protocol::HTTP::Methods do
 	it_behaves_like ValidMethod, "OPTIONS"
 	it_behaves_like ValidMethod, "TRACE"
 	it_behaves_like ValidMethod, "CONNECT"
+	it_behaves_like ValidMethod, "QUERY"
 	
-	it "defines exactly 9 methods" do
-		expect(subject.constants.length).to be == 9
+	it "defines exactly 10 methods" do
+		expect(subject.constants.length).to be == 10
 	end
 	
 	with ".valid?" do


### PR DESCRIPTION
## Summary

- Add `Protocol::HTTP::Methods::QUERY` for the HTTP QUERY method.
- Include QUERY in method validation tests and update the expected method count.
- Reference: RFC 10008, Section 2: https://www.rfc-editor.org/rfc/rfc10008.html#section-2

## Testing

- `ruby -c lib/protocol/http/methods.rb`
- `ruby -c test/protocol/http/methods.rb`
- `bundle exec sus test/protocol/http/methods.rb` could not run because the local bundle is missing locked gems, including `sus-0.35.2`.
