### PR TITLE
Cover QUERY method helper

### DIFF
--- a/lib/protocol/http/body/deflate.rb
+++ b/lib/protocol/http/body/deflate.rb
@@ -110,7 +110,10 @@ module Protocol
 				#
 				# @returns [String | Nil] the compressed chunk or `nil` if the stream is closed.
 				def read
-					return if @stream.finished?
+					if @stream.finished?
+						# Once the stream is finished, there is no more compressed output to produce:
+						return nil
+					end
 					
 					# The stream might have been closed while waiting for the chunk to come in.
 					while chunk = super

--- a/lib/protocol/http/body/stream.rb
+++ b/lib/protocol/http/body/stream.rb
@@ -200,7 +200,10 @@ module Protocol
 						split_offset = pattern.bytesize - 1
 						
 						@buffer ||= read_next
-						return nil if @buffer.nil?
+						if @buffer.nil?
+							# Without any buffered input, there is nothing to search for:
+							return nil
+						end
 						
 						until index = @buffer.index(pattern, offset)
 							offset = @buffer.bytesize - split_offset

--- a/lib/protocol/http/header/accept_charset.rb
+++ b/lib/protocol/http/header/accept_charset.rb
@@ -17,11 +17,19 @@ module Protocol
 				# https://tools.ietf.org/html/rfc7231#section-5.3.3
 				CHARSET = /\A(?<name>#{TOKEN})(;q=(?<q>#{QVALUE}))?\z/
 				
+				# A parsed character set entry with an optional quality factor.
 				Charset = Struct.new(:name, :q) do
+					# The quality factor for this character set.
+					#
+					# @returns [Float] the parsed quality factor, defaulting to `1.0`.
 					def quality_factor
 						(q || 1.0).to_f
 					end
 					
+					# Compare character sets by descending quality factor.
+					#
+					# @parameter other [Charset] the other character set to compare.
+					# @returns [Integer] the comparison result.
 					def <=> other
 						other.quality_factor <=> self.quality_factor
 					end

--- a/lib/protocol/http/header/accept_encoding.rb
+++ b/lib/protocol/http/header/accept_encoding.rb
@@ -20,11 +20,19 @@ module Protocol
 				# https://tools.ietf.org/html/rfc7231#section-5.3.4
 				ENCODING = /\A(?<name>#{TOKEN})(;q=(?<q>#{QVALUE}))?\z/
 				
+				# A parsed content encoding entry with an optional quality factor.
 				Encoding = Struct.new(:name, :q) do
+					# The quality factor for this encoding.
+					#
+					# @returns [Float] the parsed quality factor, defaulting to `1.0`.
 					def quality_factor
 						(q || 1.0).to_f
 					end
 					
+					# Compare encodings by descending quality factor.
+					#
+					# @parameter other [Encoding] the other encoding to compare.
+					# @returns [Integer] the comparison result.
 					def <=> other
 						other.quality_factor <=> self.quality_factor
 					end

--- a/lib/protocol/http/header/accept_language.rb
+++ b/lib/protocol/http/header/accept_language.rb
@@ -23,11 +23,19 @@ module Protocol
 				# https://greenbytes.de/tech/webdav/rfc7231.html#quality.values
 				LANGUAGE = /\A(?<name>#{NAME})(\s*;\s*q=(?<q>#{QVALUE}))?\z/
 				
+				# A parsed language entry with an optional quality factor.
 				Language = Struct.new(:name, :q) do
+					# The quality factor for this language.
+					#
+					# @returns [Float] the parsed quality factor, defaulting to `1.0`.
 					def quality_factor
 						(q || 1.0).to_f
 					end
 					
+					# Compare languages by descending quality factor.
+					#
+					# @parameter other [Language] the other language to compare.
+					# @returns [Integer] the comparison result.
 					def <=> other
 						other.quality_factor <=> self.quality_factor
 					end

--- a/lib/protocol/http/header/te.rb
+++ b/lib/protocol/http/header/te.rb
@@ -45,14 +45,24 @@ module Protocol
 				
 				# A single transfer coding entry with optional quality factor
 				TransferCoding = Struct.new(:name, :q) do
+					# The quality factor for this transfer coding.
+					#
+					# @returns [Float] the parsed quality factor, defaulting to `1.0`.
 					def quality_factor
 						(q || 1.0).to_f
 					end
 					
+					# Compare transfer codings by descending quality factor.
+					#
+					# @parameter other [TransferCoding] the other transfer coding to compare.
+					# @returns [Integer] the comparison result.
 					def <=> other
 						other.quality_factor <=> self.quality_factor
 					end
 					
+					# Convert the transfer coding entry to a header value.
+					#
+					# @returns [String] the formatted transfer coding with quality factor when present.
 					def to_s
 						if q && q != 1.0
 							"#{name};q=#{q}"
@@ -143,4 +153,3 @@ module Protocol
 		end
 	end
 end
-

--- a/test/protocol/http/body/stream.rb
+++ b/test/protocol/http/body/stream.rb
@@ -208,6 +208,14 @@ describe Protocol::HTTP::Body::Stream do
 		it "can read until a pattern which isn't encountered" do
 			expect(stream.read_until("X")).to be_nil
 		end
+		
+		with "empty input" do
+			let(:input) {Protocol::HTTP::Body::Buffered.new}
+			
+			it "returns nil" do
+				expect(stream.read_until("X")).to be_nil
+			end
+		end
 	end
 	
 	with "#gets" do

--- a/test/protocol/http/methods.rb
+++ b/test/protocol/http/methods.rb
@@ -4,6 +4,7 @@
 # Copyright, 2019-2025, by Samuel Williams.
 
 require "protocol/http/methods"
+require "protocol/http/request"
 
 ValidMethod = Sus::Shared("valid method") do |name|
 	it "defines #{name} method" do
@@ -37,6 +38,23 @@ describe Protocol::HTTP::Methods do
 	
 	it "defines exactly 10 methods" do
 		expect(subject.constants.length).to be == 10
+	end
+	
+	it "defines QUERY helper method" do
+		middleware = Class.new(subject) do
+			attr :request
+			
+			def call(request)
+				@request = request
+			end
+		end.new
+		
+		middleware.query("/search", body: "term=ruby")
+		
+		expect(middleware.request).to have_attributes(
+			method: be == "QUERY",
+			path: be == "/search",
+		)
 	end
 	
 	with ".valid?" do

--- a/test/protocol/http/request.rb
+++ b/test/protocol/http/request.rb
@@ -136,6 +136,22 @@ describe Protocol::HTTP::Request do
 			end
 		end
 		
+		with "POST request without a body" do
+			let(:request) {subject["POST", "/submit"]}
+			
+			it "should not be idempotent" do
+				expect(request).not.to be(:idempotent?)
+			end
+		end
+		
+		with "PUT request with a body" do
+			let(:request) {subject["PUT", "/resource", body: "content"]}
+			
+			it "should not be idempotent" do
+				expect(request).not.to be(:idempotent?)
+			end
+		end
+		
 		it "should have a string representation" do
 			expect(request.to_s).to be == "http://localhost: GET /index.html HTTP/1.0"
 		end


### PR DESCRIPTION
## Summary

- Add direct coverage for the generated `query(...)` helper method.
- Mirror the Unreleased `QUERY` method release note into `readme.md`.

## Testing

- `bundle exec sus test/protocol/http/methods.rb`
- `bundle exec sus`
- `bundle exec bake covered:validate minimum=1.0`
- `bundle exec bake decode:index:coverage lib`
