### PR TITLE
Treat QUERY requests as idempotent

### DIFF
--- a/lib/protocol/http/request.rb
+++ b/lib/protocol/http/request.rb
@@ -134,6 +134,8 @@ module Protocol
 			
 			# Whether the request can be replayed without side-effects.
 			def idempotent?
+				return true if @method == Methods::QUERY
+				
 				@method != Methods::POST && (@body.nil? || @body.empty?)
 			end
 			

--- a/lib/protocol/http/request.rb
+++ b/lib/protocol/http/request.rb
@@ -134,9 +134,23 @@ module Protocol
 			
 			# Whether the request can be replayed without side-effects.
 			def idempotent?
-				return true if @method == Methods::QUERY
+				# QUERY requests are idempotent, even if they have a body:
+				if @method == Methods::QUERY
+					return true
+				end
 				
-				@method != Methods::POST && (@body.nil? || @body.empty?)
+				# POST requests are not idempotent, even if they have no body:
+				if @method == Methods::POST
+					return false
+				end
+				
+				# All other requests are idempotent if they have no body:
+				if @body.nil? || @body.empty?
+					return true
+				end
+				
+				# Otherwise, we don't know if the request is idempotent or not, so we assume it is not:
+				return false
 			end
 			
 			# Convert the request to a hash, suitable for serialization.

--- a/test/protocol/http/request.rb
+++ b/test/protocol/http/request.rb
@@ -128,6 +128,14 @@ describe Protocol::HTTP::Request do
 			expect(request).to be(:idempotent?)
 		end
 		
+		with "QUERY request with a body" do
+			let(:request) {subject["QUERY", "/search", body: "term=ruby"]}
+			
+			it "should be idempotent" do
+				expect(request).to be(:idempotent?)
+			end
+		end
+		
 		it "should have a string representation" do
 			expect(request.to_s).to be == "http://localhost: GET /index.html HTTP/1.0"
 		end


### PR DESCRIPTION
## Summary

- Treat `QUERY` requests as idempotent even when they include a request body.
- Add coverage for a body-bearing `QUERY` request.

## Testing

- `bundle exec sus test/protocol/http/request.rb`
- `bundle exec sus`
- `COVERAGE=PartialSummary bundle exec sus`
