### PR TITLE
Add request retry preparation

### DIFF
--- a/lib/protocol/http/request.rb
+++ b/lib/protocol/http/request.rb
@@ -153,14 +153,9 @@ module Protocol
 				return false
 			end
 			
-			# Prepare the request body to be sent again, if it is safe to retry.
-			# @returns [Boolean] Whether the request was prepared for retry.
-			def retry!
-				# Only idempotent request methods can be retried safely.
-				if @method == Methods::POST || @method == Methods::PATCH || @method == Methods::CONNECT
-					return false
-				end
-				
+			# Rewind the request body so it can be sent again.
+			# @returns [Boolean] Whether the request body was rewound.
+			def rewind!
 				# Requests without a body can be sent again immediately.
 				if body = @body
 					# Empty, non-rewindable bodies have nothing left to send.
@@ -179,6 +174,17 @@ module Protocol
 				end
 				
 				return true
+			end
+			
+			# Prepare the request body to be sent again, if it is safe to retry.
+			# @returns [Boolean] Whether the request was prepared for retry.
+			def retry!
+				# Only idempotent request methods can be retried safely.
+				if @method == Methods::POST || @method == Methods::PATCH || @method == Methods::CONNECT
+					return false
+				end
+				
+				return self.rewind!
 			end
 			
 			# Convert the request to a hash, suitable for serialization.

--- a/lib/protocol/http/request.rb
+++ b/lib/protocol/http/request.rb
@@ -132,25 +132,27 @@ module Protocol
 				self.new(scheme, authority, method, path, nil, headers, body, protocol, interim_response)
 			end
 			
-			# Whether the request can be replayed without side-effects.
+			# Whether the request method is idempotent according to HTTP semantics.
 			def idempotent?
-				# QUERY requests are idempotent, even if they have a body:
-				if @method == Methods::QUERY
-					return true
+				case @method
+				when Methods::POST, Methods::PATCH, Methods::CONNECT
+					false
+				else
+					true
 				end
+			end
+			
+			# Prepare the request body to be sent again, if it is safe to retry.
+			# @returns [Boolean] Whether the request was prepared for retry.
+			def retry!
+				return false unless self.idempotent?
+				return true unless body = @body
+				return true if body.empty? && !body.rewindable?
+				return false unless body.rewindable?
 				
-				# POST requests are not idempotent, even if they have no body:
-				if @method == Methods::POST
-					return false
-				end
+				return false unless body.rewind
 				
-				# All other requests are idempotent if they have no body:
-				if @body.nil? || @body.empty?
-					return true
-				end
-				
-				# Otherwise, we don't know if the request is idempotent or not, so we assume it is not:
-				return false
+				return true
 			end
 			
 			# Convert the request to a hash, suitable for serialization.

--- a/lib/protocol/http/request.rb
+++ b/lib/protocol/http/request.rb
@@ -156,18 +156,11 @@ module Protocol
 			# Rewind the request body so it can be sent again.
 			# @returns [Boolean] Whether the request body was rewound.
 			def rewind!
-				# Requests without a body can be sent again immediately.
 				if body = @body
-					# Bodies must be rewindable so the same data can be sent again.
-					if !body.rewindable?
-						return false
-					end
-					
-					if !body.rewind
-						return false
-					end
+					return body.rewind
 				end
 				
+				# Requests without a body can be sent again immediately.
 				return true
 			end
 			

--- a/lib/protocol/http/request.rb
+++ b/lib/protocol/http/request.rb
@@ -132,21 +132,32 @@ module Protocol
 				self.new(scheme, authority, method, path, nil, headers, body, protocol, interim_response)
 			end
 			
-			# Whether the request method is idempotent according to HTTP semantics.
+			# Whether the request can be replayed without side-effects.
 			def idempotent?
-				case @method
-				when Methods::POST, Methods::PATCH, Methods::CONNECT
-					false
-				else
-					true
+				# QUERY requests are idempotent, even if they have a body:
+				if @method == Methods::QUERY
+					return true
 				end
+				
+				# POST requests are not idempotent, even if they have no body:
+				if @method == Methods::POST
+					return false
+				end
+				
+				# All other requests are idempotent if they have no body:
+				if @body.nil? || @body.empty?
+					return true
+				end
+				
+				# Otherwise, we don't know if the request is idempotent or not, so we assume it is not:
+				return false
 			end
 			
 			# Prepare the request body to be sent again, if it is safe to retry.
 			# @returns [Boolean] Whether the request was prepared for retry.
 			def retry!
-				# Only idempotent requests can be retried safely.
-				if !self.idempotent?
+				# Only idempotent request methods can be retried safely.
+				if @method == Methods::POST || @method == Methods::PATCH || @method == Methods::CONNECT
 					return false
 				end
 				

--- a/lib/protocol/http/request.rb
+++ b/lib/protocol/http/request.rb
@@ -158,12 +158,7 @@ module Protocol
 			def rewind!
 				# Requests without a body can be sent again immediately.
 				if body = @body
-					# Empty, non-rewindable bodies have nothing left to send.
-					if body.empty? && !body.rewindable?
-						return true
-					end
-					
-					# Non-empty bodies must be rewindable so the same data can be sent again.
+					# Bodies must be rewindable so the same data can be sent again.
 					if !body.rewindable?
 						return false
 					end

--- a/lib/protocol/http/request.rb
+++ b/lib/protocol/http/request.rb
@@ -145,12 +145,27 @@ module Protocol
 			# Prepare the request body to be sent again, if it is safe to retry.
 			# @returns [Boolean] Whether the request was prepared for retry.
 			def retry!
-				return false unless self.idempotent?
-				return true unless body = @body
-				return true if body.empty? && !body.rewindable?
-				return false unless body.rewindable?
+				# Only idempotent requests can be retried safely.
+				if !self.idempotent?
+					return false
+				end
 				
-				return false unless body.rewind
+				# Requests without a body can be sent again immediately.
+				if body = @body
+					# Empty, non-rewindable bodies have nothing left to send.
+					if body.empty? && !body.rewindable?
+						return true
+					end
+					
+					# Non-empty bodies must be rewindable so the same data can be sent again.
+					if !body.rewindable?
+						return false
+					end
+					
+					if !body.rewind
+						return false
+					end
+				end
 				
 				return true
 			end

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Add `Protocol::HTTP::Request#rewind!` and `#retry!` for preparing requests to be sent again.
+
 ## v0.63.0
 
   - Add support for the HTTP `QUERY` method.

--- a/test/protocol/http/request.rb
+++ b/test/protocol/http/request.rb
@@ -147,8 +147,50 @@ describe Protocol::HTTP::Request do
 		with "PUT request with a body" do
 			let(:request) {subject["PUT", "/resource", body: "content"]}
 			
+			it "should be idempotent" do
+				expect(request).to be(:idempotent?)
+			end
+		end
+		
+		with "PATCH request without a body" do
+			let(:request) {subject["PATCH", "/resource"]}
+			
 			it "should not be idempotent" do
 				expect(request).not.to be(:idempotent?)
+			end
+		end
+		
+		with "#retry!" do
+			it "allows idempotent requests without a body" do
+				expect(request.retry!).to be == true
+			end
+			
+			with "idempotent request with a rewindable body" do
+				let(:request) {subject["PUT", "/resource", body: "content"]}
+				
+				it "rewinds the body" do
+					expect(request.body.read).to be == "content"
+					
+					expect(request.retry!).to be == true
+					expect(request.body.read).to be == "content"
+				end
+			end
+			
+			with "idempotent request with a non-rewindable body" do
+				let(:body) {Protocol::HTTP::Body::Readable.new}
+				let(:request) {subject.new(nil, nil, "PUT", "/resource", nil, headers, body)}
+				
+				it "does not allow retry" do
+					expect(request.retry!).to be == false
+				end
+			end
+			
+			with "non-idempotent request" do
+				let(:request) {subject["POST", "/submit"]}
+				
+				it "does not allow retry" do
+					expect(request.retry!).to be == false
+				end
 			end
 		end
 		

--- a/test/protocol/http/request.rb
+++ b/test/protocol/http/request.rb
@@ -184,6 +184,51 @@ describe Protocol::HTTP::Request do
 					expect(request.rewind!).to be == false
 				end
 			end
+			
+			with "request with a consumed non-rewindable body" do
+				let(:body) do
+					Class.new(Protocol::HTTP::Body::Readable) do
+						def initialize
+							@chunk = "content"
+						end
+						
+						def read
+							chunk = @chunk
+							@chunk = nil
+							return chunk
+						end
+						
+						def empty?
+							@chunk.nil?
+						end
+					end.new
+				end
+				
+				let(:request) {subject.new(nil, nil, "PUT", "/resource", nil, headers, body)}
+				
+				it "does not treat empty as rewindable" do
+					expect(request.body.read).to be == "content"
+					expect(request.body).to be(:empty?)
+					
+					expect(request.rewind!).to be == false
+				end
+			end
+			
+			with "request with an empty non-rewindable body" do
+				let(:body) do
+					Class.new(Protocol::HTTP::Body::Readable) do
+						def empty?
+							true
+						end
+					end.new
+				end
+				
+				let(:request) {subject.new(nil, nil, "PUT", "/resource", nil, headers, body)}
+				
+				it "does not rewind" do
+					expect(request.rewind!).to be == false
+				end
+			end
 		end
 		
 		with "#retry!" do

--- a/test/protocol/http/request.rb
+++ b/test/protocol/http/request.rb
@@ -147,16 +147,16 @@ describe Protocol::HTTP::Request do
 		with "PUT request with a body" do
 			let(:request) {subject["PUT", "/resource", body: "content"]}
 			
-			it "should be idempotent" do
-				expect(request).to be(:idempotent?)
+			it "should not be idempotent" do
+				expect(request).not.to be(:idempotent?)
 			end
 		end
 		
 		with "PATCH request without a body" do
 			let(:request) {subject["PATCH", "/resource"]}
 			
-			it "should not be idempotent" do
-				expect(request).not.to be(:idempotent?)
+			it "should be idempotent" do
+				expect(request).to be(:idempotent?)
 			end
 		end
 		
@@ -168,7 +168,7 @@ describe Protocol::HTTP::Request do
 			with "idempotent request with a rewindable body" do
 				let(:request) {subject["PUT", "/resource", body: "content"]}
 				
-				it "rewinds the body" do
+				it "allows retry and rewinds the body" do
 					expect(request.body.read).to be == "content"
 					
 					expect(request.retry!).to be == true
@@ -187,6 +187,14 @@ describe Protocol::HTTP::Request do
 			
 			with "non-idempotent request" do
 				let(:request) {subject["POST", "/submit"]}
+				
+				it "does not allow retry" do
+					expect(request.retry!).to be == false
+				end
+			end
+			
+			with "PATCH request" do
+				let(:request) {subject["PATCH", "/resource"]}
 				
 				it "does not allow retry" do
 					expect(request.retry!).to be == false

--- a/test/protocol/http/request.rb
+++ b/test/protocol/http/request.rb
@@ -160,6 +160,32 @@ describe Protocol::HTTP::Request do
 			end
 		end
 		
+		with "#rewind!" do
+			it "allows requests without a body" do
+				expect(request.rewind!).to be == true
+			end
+			
+			with "request with a rewindable body" do
+				let(:request) {subject["POST", "/submit", body: "content"]}
+				
+				it "rewinds the body" do
+					expect(request.body.read).to be == "content"
+					
+					expect(request.rewind!).to be == true
+					expect(request.body.read).to be == "content"
+				end
+			end
+			
+			with "request with a non-rewindable body" do
+				let(:body) {Protocol::HTTP::Body::Readable.new}
+				let(:request) {subject.new(nil, nil, "PUT", "/resource", nil, headers, body)}
+				
+				it "does not rewind" do
+					expect(request.rewind!).to be == false
+				end
+			end
+		end
+		
 		with "#retry!" do
 			it "allows idempotent requests without a body" do
 				expect(request.retry!).to be == true


### PR DESCRIPTION
## Summary

- Add `Protocol::HTTP::Request#rewind!` to prepare a request body to be sent again, independent of request method semantics.
- Add `Protocol::HTTP::Request#retry!` to prepare requests for safe ambiguous retries by checking method semantics and delegating to `rewind!`.
- Preserve the existing `Request#idempotent?` behavior for compatibility with existing clients.
- Cover rewind/retry preparation for no body, rewindable bodies, non-rewindable bodies, and non-idempotent methods.

## Intended Usage

- Use `request.rewind!` when the transport knows the previous attempt was not processed, e.g. `Protocol::HTTP::RefusedError`.
- Use `request.retry!` when retrying an ambiguous failure, where method semantics matter.

## Testing

- `bundle exec sus test/protocol/http/request.rb`
- `bundle exec sus`