### PR TITLE
Harden Accept header parsing

### DIFF
--- a/lib/protocol/http/header/accept.rb
+++ b/lib/protocol/http/header/accept.rb
@@ -65,8 +65,6 @@ module Protocol
 				# @parameter value [String] a raw header value containing comma-separated media types.
 				# @returns [Accept] a new instance containing the parsed media types.
 				def self.parse(value)
-					raise TypeError, "Expected a String, got: #{value.class}" unless value.is_a?(String)
-					
 					self.new << value
 				end
 				
@@ -104,6 +102,8 @@ module Protocol
 				private
 				
 				def split_values(value)
+					raise TypeError, "Expected a String, got: #{value.class}" unless value.is_a?(String)
+					
 					return [] if value.empty?
 					
 					values = []

--- a/lib/protocol/http/header/accept.rb
+++ b/lib/protocol/http/header/accept.rb
@@ -82,7 +82,7 @@ module Protocol
 				#
 				# @parameter value [String] a raw header value containing one or more media types separated by commas.
 				def << value
-					self.concat(split_values(value))
+					self.concat(value.scan(SEPARATOR).map(&:strip))
 				end
 				
 				# Converts the parsed header value into a raw header value.
@@ -108,12 +108,6 @@ module Protocol
 				end
 				
 				private
-				
-				def split_values(value)
-					raise TypeError, "Expected a String, got: #{value.class}" unless value.is_a?(String)
-					
-					value.scan(SEPARATOR).map(&:strip)
-				end
 				
 				def parse_media_range(value)
 					if match = value.match(MEDIA_RANGE)

--- a/lib/protocol/http/header/accept.rb
+++ b/lib/protocol/http/header/accept.rb
@@ -15,12 +15,12 @@ module Protocol
 			class Accept < Split
 				# Regular expression used to split values on commas, with optional surrounding whitespace, taking into account quoted strings.
 				SEPARATOR = /
-					(?:
-						"(?:[^"\\]|\\.)*" # Match quoted strings, including quoted pairs.
-						|
-						[^,"]+ # Match non-quoted strings until a comma or quote.
+					(?:                       # Start non-capturing group
+						"(?:[^"\\]|\\.)*"       # Match quoted strings, including quoted pairs
+						|                       # OR
+						[^,"]+                  # Match non-quoted strings until a comma or quote
 					)+
-					(?=,|\z)
+					(?=,|\z)                  # Match until a comma or end of string
 				/x
 				
 				ParseError = Class.new(Error)

--- a/lib/protocol/http/header/accept.rb
+++ b/lib/protocol/http/header/accept.rb
@@ -8,13 +8,21 @@ require_relative "split"
 require_relative "../quoted_string"
 require_relative "../error"
 
-require "strscan"
-
 module Protocol
 	module HTTP
 		module Header
 			# The `accept-content-type` header represents a list of content-types that the client can accept.
 			class Accept < Split
+				# Regular expression used to split values on commas, with optional surrounding whitespace, taking into account quoted strings.
+				SEPARATOR = /
+					(?:
+						"(?:[^"\\]|\\.)*" # Match quoted strings, including quoted pairs.
+						|
+						[^,"]+ # Match non-quoted strings until a comma or quote.
+					)+
+					(?=,|\z)
+				/x
+				
 				ParseError = Class.new(Error)
 				
 				MEDIA_RANGE = /\A(?<type>#{TOKEN})\/(?<subtype>#{TOKEN})(?<parameters>.*)\z/
@@ -104,34 +112,7 @@ module Protocol
 				def split_values(value)
 					raise TypeError, "Expected a String, got: #{value.class}" unless value.is_a?(String)
 					
-					return [] if value.empty?
-					
-					values = []
-					start = 0
-					quoted = false
-					escaped = false
-					
-					value.each_char.with_index do |character, index|
-						if quoted
-							if escaped
-								escaped = false
-							elsif character == "\\"
-								escaped = true
-							elsif character == '"'
-								quoted = false
-							end
-						elsif character == '"'
-							quoted = true
-						elsif character == ","
-							values << value[start...index].strip
-							start = index + 1
-						end
-					end
-					
-					raise ParseError, "Unterminated quoted string: #{value.inspect}" if quoted
-					
-					values << value[start..].strip
-					return values
+					value.scan(SEPARATOR).map(&:strip)
 				end
 				
 				def parse_media_range(value)
@@ -139,12 +120,15 @@ module Protocol
 						type = match[:type]
 						subtype = match[:subtype]
 						parameters = {}
-						scanner = StringScanner.new(match[:parameters])
+						parameters_string = match[:parameters]
+						offset = 0
 						
-						while scanner.scan(PARAMETER)
-							key = scanner[:key]
-							value = scanner[:value]
-							quoted_value = scanner[:quoted_value]
+						parameters_string.scan(PARAMETER) do |key, value, quoted_value|
+							parameter_match = Regexp.last_match
+							unless parameter_match.begin(0) == offset
+								raise ParseError, "Invalid media range parameters: #{parameters_string[offset..].inspect}"
+							end
+							offset = parameter_match.end(0)
 							
 							if key.casecmp?("q")
 								if quoted_value || parameters.key?("q") || !value.match?(/\A(?:#{QVALUE})\z/)
@@ -161,8 +145,8 @@ module Protocol
 							parameters[key] = value
 						end
 						
-						unless scanner.eos?
-							raise ParseError, "Invalid media range parameters: #{scanner.rest.inspect}"
+						unless offset == parameters_string.length
+							raise ParseError, "Invalid media range parameters: #{parameters_string[offset..].inspect}"
 						end
 						
 						if (type.include?("*") && type != "*") || (subtype.include?("*") && subtype != "*") || (type == "*" && subtype != "*")

--- a/lib/protocol/http/header/accept.rb
+++ b/lib/protocol/http/header/accept.rb
@@ -8,21 +8,13 @@ require_relative "split"
 require_relative "../quoted_string"
 require_relative "../error"
 
+require "strscan"
+
 module Protocol
 	module HTTP
 		module Header
 			# The `accept-content-type` header represents a list of content-types that the client can accept.
 			class Accept < Split
-				# Regular expression used to split values on commas, with optional surrounding whitespace, taking into account quoted strings.
-				SEPARATOR = /
-					(?:            # Start non-capturing group
-						"[^"\\]*"    # Match quoted strings (no escaping of quotes within)
-						|            # OR
-						[^,"]+       # Match non-quoted strings until a comma or quote
-					)+
-					(?=,|\z)       # Match until a comma or end of string
-				/x
-				
 				ParseError = Class.new(Error)
 				
 				MEDIA_RANGE = /\A(?<type>#{TOKEN})\/(?<subtype>#{TOKEN})(?<parameters>.*)\z/
@@ -73,7 +65,9 @@ module Protocol
 				# @parameter value [String] a raw header value containing comma-separated media types.
 				# @returns [Accept] a new instance containing the parsed media types.
 				def self.parse(value)
-					self.new(value.scan(SEPARATOR).map(&:strip))
+					raise TypeError, "Expected a String, got: #{value.class}" unless value.is_a?(String)
+					
+					self.new << value
 				end
 				
 				# Adds one or more comma-separated values to the header.
@@ -82,7 +76,7 @@ module Protocol
 				#
 				# @parameter value [String] a raw header value containing one or more media types separated by commas.
 				def << value
-					self.concat(value.scan(SEPARATOR).map(&:strip))
+					self.concat(split_values(value))
 				end
 				
 				# Converts the parsed header value into a raw header value.
@@ -109,18 +103,70 @@ module Protocol
 				
 				private
 				
+				def split_values(value)
+					return [] if value.empty?
+					
+					values = []
+					start = 0
+					quoted = false
+					escaped = false
+					
+					value.each_char.with_index do |character, index|
+						if quoted
+							if escaped
+								escaped = false
+							elsif character == "\\"
+								escaped = true
+							elsif character == '"'
+								quoted = false
+							end
+						elsif character == '"'
+							quoted = true
+						elsif character == ","
+							values << value[start...index].strip
+							start = index + 1
+						end
+					end
+					
+					raise ParseError, "Unterminated quoted string: #{value.inspect}" if quoted
+					
+					values << value[start..].strip
+					return values
+				end
+				
 				def parse_media_range(value)
 					if match = value.match(MEDIA_RANGE)
 						type = match[:type]
 						subtype = match[:subtype]
 						parameters = {}
+						scanner = StringScanner.new(match[:parameters])
 						
-						match[:parameters].scan(PARAMETER) do |key, value, quoted_value|
+						while scanner.scan(PARAMETER)
+							key = scanner[:key]
+							value = scanner[:value]
+							quoted_value = scanner[:quoted_value]
+							
+							if key.casecmp?("q")
+								if quoted_value || parameters.key?("q") || !value.match?(/\A(?:#{QVALUE})\z/)
+									raise ParseError, "Invalid quality factor: #{value.inspect}"
+								end
+								
+								key = "q"
+							end
+							
 							if quoted_value
 								value = QuotedString.unquote(quoted_value)
 							end
 							
 							parameters[key] = value
+						end
+						
+						unless scanner.eos?
+							raise ParseError, "Invalid media range parameters: #{scanner.rest.inspect}"
+						end
+						
+						if (type.include?("*") && type != "*") || (subtype.include?("*") && subtype != "*") || (type == "*" && subtype != "*")
+							raise ParseError, "Invalid wildcards in media range: #{type}/#{subtype}"
 						end
 						
 						return MediaRange.new(type, subtype, parameters)

--- a/lib/protocol/http/header/accept.rb
+++ b/lib/protocol/http/header/accept.rb
@@ -73,7 +73,7 @@ module Protocol
 				# @parameter value [String] a raw header value containing comma-separated media types.
 				# @returns [Accept] a new instance containing the parsed media types.
 				def self.parse(value)
-					self.new << value
+					self.new(value.scan(SEPARATOR).map(&:strip))
 				end
 				
 				# Adds one or more comma-separated values to the header.

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Improve `Accept` header parsing for quoted pairs, malformed parameters, invalid wildcards, and invalid quality factors.
+
 ## v0.64.0
 
   - Add `Protocol::HTTP::Request#rewind!` and `#retry!` for preparing requests to be sent again.

--- a/test/protocol/http/header/accept.rb
+++ b/test/protocol/http/header/accept.rb
@@ -143,6 +143,12 @@ describe Protocol::HTTP::Header::Accept do
 		end
 	end
 	
+	with "#<<" do
+		it "rejects nil" do
+			expect{subject.new << nil}.to raise_exception(TypeError)
+		end
+	end
+	
 	with "text/html;q=0, text/plain;q=0.123, application/json;q=1.000" do
 		it "accepts standard quality factors" do
 			expect(media_ranges.collect(&:quality_factor)).to be == [1.0, 0.123, 0.0]

--- a/test/protocol/http/header/accept.rb
+++ b/test/protocol/http/header/accept.rb
@@ -136,20 +136,10 @@ describe Protocol::HTTP::Header::Accept do
 			expect(subject.parse("").media_ranges).to be == []
 		end
 		
-		it "rejects nil" do
-			expect{subject.parse(nil)}.to raise_exception(TypeError)
-		end
-		
 		it "ignores empty list members" do
 			expect(subject.parse(", text/html,").media_ranges).to have_attributes(
 				length: be == 1,
 			)
-		end
-	end
-	
-	with "#<<" do
-		it "rejects nil" do
-			expect{subject.new << nil}.to raise_exception(TypeError)
 		end
 	end
 	

--- a/test/protocol/http/header/accept.rb
+++ b/test/protocol/http/header/accept.rb
@@ -84,6 +84,71 @@ describe Protocol::HTTP::Header::Accept do
 		end
 	end
 	
+	with 'foo/bar;key="A,B,C", text/plain;note="a,b; c\\"d"' do
+		it "preserves commas and escapes in quoted parameters" do
+			expect(header.length).to be == 2
+			expect(media_ranges[0].parameters).to have_keys(
+				"key" => be == "A,B,C",
+			)
+			expect(media_ranges[1].parameters).to have_keys(
+				"note" => be == 'a,b; c"d',
+			)
+		end
+	end
+	
+	with "invalid media ranges" do
+		it "rejects malformed parameters" do
+			[
+				",",
+				"text/html,",
+				"text/html;",
+				"text/html;invalid",
+				"text/html;charset=",
+				'text/html;charset="unterminated',
+			].each do |value|
+				expect{subject.parse(value).media_ranges}.to raise_exception(Protocol::HTTP::Header::Accept::ParseError)
+			end
+		end
+		
+		it "rejects invalid wildcard forms" do
+			[
+				"*/json",
+				"text/*+json",
+				"te*t/plain",
+			].each do |value|
+				expect{subject.parse(value).media_ranges}.to raise_exception(Protocol::HTTP::Header::Accept::ParseError)
+			end
+		end
+		
+		it "rejects invalid quality factors" do
+			[
+				"text/html;q=1.1",
+				"text/html;q=0.1234",
+				"text/html;q=invalid",
+				'text/html;q="0.5"',
+				"text/html;q=0.5;q=0.4",
+			].each do |value|
+				expect{subject.parse(value).media_ranges}.to raise_exception(Protocol::HTTP::Header::Accept::ParseError)
+			end
+		end
+	end
+	
+	with ".parse" do
+		it "accepts an empty string" do
+			expect(subject.parse("").media_ranges).to be == []
+		end
+		
+		it "rejects nil" do
+			expect{subject.parse(nil)}.to raise_exception(TypeError)
+		end
+	end
+	
+	with "text/html;q=0, text/plain;q=0.123, application/json;q=1.000" do
+		it "accepts standard quality factors" do
+			expect(media_ranges.collect(&:quality_factor)).to be == [1.0, 0.123, 0.0]
+		end
+	end
+	
 	with ".coerce" do
 		it "coerces array to Accept" do
 			result = subject.coerce(["text/html", "application/json"])

--- a/test/protocol/http/header/accept.rb
+++ b/test/protocol/http/header/accept.rb
@@ -101,6 +101,7 @@ describe Protocol::HTTP::Header::Accept do
 			[
 				"text/html;",
 				"text/html;invalid",
+				"text/html;invalid;q=0.5",
 				"text/html;charset=",
 				'text/html;charset="unterminated',
 			].each do |value|

--- a/test/protocol/http/header/accept.rb
+++ b/test/protocol/http/header/accept.rb
@@ -99,8 +99,6 @@ describe Protocol::HTTP::Header::Accept do
 	with "invalid media ranges" do
 		it "rejects malformed parameters" do
 			[
-				",",
-				"text/html,",
 				"text/html;",
 				"text/html;invalid",
 				"text/html;charset=",
@@ -140,6 +138,12 @@ describe Protocol::HTTP::Header::Accept do
 		
 		it "rejects nil" do
 			expect{subject.parse(nil)}.to raise_exception(TypeError)
+		end
+		
+		it "ignores empty list members" do
+			expect(subject.parse(", text/html,").media_ranges).to have_attributes(
+				length: be == 1,
+			)
 		end
 	end
 	


### PR DESCRIPTION
## Summary

- add coverage for quoted parameters, malformed input, wildcards, and quality factors
- support quoted pairs when splitting comma-separated media ranges
- require complete parameter consumption and validate wildcard and `q` forms
- preserve the existing regex-and-`scan` parser structure

## Verification

- `bundle exec sus test/protocol/http/header/accept.rb`
- `bundle exec bake test`
- `bundle exec rubocop lib/protocol/http/header/accept.rb test/protocol/http/header/accept.rb`
- `bundle exec bake decode:index:coverage lib`