### PR TITLE
Introduce Protocol::HTTP::RemoteError

### DIFF
--- a/lib/protocol/http/error.rb
+++ b/lib/protocol/http/error.rb
@@ -14,6 +14,11 @@ module Protocol
 		class RefusedError < Error
 		end
 		
+		# Raised when the remote endpoint fails while processing an HTTP stream or request.
+		# This error does not indicate whether application processing occurred. Where available, the protocol-specific error should be attached as the cause.
+		class RemoteError < Error
+		end
+		
 		# @deprecated Use {RefusedError} instead.
 		RequestRefusedError = RefusedError
 		

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Introduce `Protocol::HTTP::RemoteError` for remote endpoint failures where application processing may have occurred.
+
 ## v0.65.0
 
   - Improve `Accept` header parsing for quoted pairs, malformed parameters, invalid wildcards, and invalid quality factors.

--- a/test/protocol/http/error.rb
+++ b/test/protocol/http/error.rb
@@ -23,6 +23,20 @@ describe Protocol::HTTP::RefusedError do
 	end
 end
 
+describe Protocol::HTTP::RemoteError do
+	let(:error) {subject.new("Remote endpoint encountered an internal error.")}
+	
+	with "#initialize" do
+		it "is an HTTP error" do
+			expect(error).to be_a(Protocol::HTTP::Error)
+		end
+		
+		it "has a descriptive message" do
+			expect(error.message).to be == "Remote endpoint encountered an internal error."
+		end
+	end
+end
+
 describe Protocol::HTTP::DuplicateHeaderError do
 	let(:key) {"content-length"}
 	let(:existing_value) {"100"}


### PR DESCRIPTION
## Summary

- Add `Protocol::HTTP::RemoteError` for failures originating at the remote endpoint.
- Document that application processing may already have occurred.
- Preserve protocol-specific detail through the standard exception cause chain at translation sites.

This provides a protocol-neutral exception for cases such as HTTP/2 `RST_STREAM(INTERNAL_ERROR)` and HTTP/3 `H3_INTERNAL_ERROR`. Higher-level clients can apply their own bounded retry policy while retaining the underlying stream error as `Exception#cause`. This is a prerequisite for addressing socketry/async-http#231; it does not itself change retry behavior.

## Testing

- `sus test/protocol/http/error.rb` — 9 passed, 15 assertions
- `sus` — 743 passed, 1,509 assertions
- `rubocop lib/protocol/http/error.rb test/protocol/http/error.rb` — no offenses