### PR TITLE
Test coverage with Ruby head

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -21,6 +21,7 @@ jobs:
         
         ruby:
           - ruby
+          - head
     
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
Ruby 4.0.6 currently reports three exercised loop-condition lines as uncovered, leaving the combined macOS/Linux result at 99.84% (1835/1838 lines). Ruby head contains the coverage fix.

Temporarily add Ruby head to this repository’s coverage matrix so its results are merged with the stable Ruby artifacts. The PR coverage run confirms this restores 100.0% coverage (1838/1838 lines).

This can be removed once the Ruby fix is backported to the stable release used by CI. `bake-modernize` is intentionally unchanged because this is a temporary workaround for affected repositories.