### PR TITLE
Classify header parse errors as bad requests.

### DIFF
--- a/lib/protocol/http/header/accept.rb
+++ b/lib/protocol/http/header/accept.rb
@@ -23,7 +23,9 @@ module Protocol
 					(?=,|\z)                  # Match until a comma or end of string
 				/x
 				
-				ParseError = Class.new(Error)
+				ParseError = Class.new(Error) do
+					include BadRequest
+				end
 				
 				MEDIA_RANGE = /\A(?<type>#{TOKEN})\/(?<subtype>#{TOKEN})(?<parameters>.*)\z/
 				

--- a/lib/protocol/http/header/accept_charset.rb
+++ b/lib/protocol/http/header/accept_charset.rb
@@ -12,7 +12,9 @@ module Protocol
 		module Header
 			# The `accept-charset` header represents a list of character sets that the client can accept.
 			class AcceptCharset < Split
-				ParseError = Class.new(Error)
+				ParseError = Class.new(Error) do
+					include BadRequest
+				end
 				
 				# https://tools.ietf.org/html/rfc7231#section-5.3.3
 				CHARSET = /\A(?<name>#{TOKEN})(;q=(?<q>#{QVALUE}))?\z/

--- a/lib/protocol/http/header/accept_encoding.rb
+++ b/lib/protocol/http/header/accept_encoding.rb
@@ -12,7 +12,9 @@ module Protocol
 		module Header
 			# The `accept-encoding` header represents a list of encodings that the client can accept.
 			class AcceptEncoding < Split
-				ParseError = Class.new(Error)
+				ParseError = Class.new(Error) do
+					include BadRequest
+				end
 				
 				# https://tools.ietf.org/html/rfc7231#section-5.3.1
 				QVALUE = /0(\.[0-9]{0,3})?|1(\.[0]{0,3})?/

--- a/lib/protocol/http/header/accept_language.rb
+++ b/lib/protocol/http/header/accept_language.rb
@@ -12,7 +12,9 @@ module Protocol
 		module Header
 			# The `accept-language` header represents a list of languages that the client can accept.
 			class AcceptLanguage < Split
-				ParseError = Class.new(Error)
+				ParseError = Class.new(Error) do
+					include BadRequest
+				end
 				
 				# https://tools.ietf.org/html/rfc3066#section-2.1
 				NAME = /\*|[A-Z]{1,8}(-[A-Z0-9]{1,8})*/i

--- a/lib/protocol/http/header/digest.rb
+++ b/lib/protocol/http/header/digest.rb
@@ -23,7 +23,9 @@ module Protocol
 			# # => "sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=, md5=9bb58f26192e4ba00f01e2e7b136bbd8"
 			# ```
 			class Digest < Split
-				ParseError = Class.new(Error)
+				ParseError = Class.new(Error) do
+					include BadRequest
+				end
 				
 				# https://tools.ietf.org/html/rfc3230#section-4.3.2
 				ENTRY = /\A(?<algorithm>[a-zA-Z0-9][a-zA-Z0-9\-]*)\s*=\s*(?<value>.*)\z/

--- a/lib/protocol/http/header/range.rb
+++ b/lib/protocol/http/header/range.rb
@@ -10,7 +10,9 @@ module Protocol
 		module Header
 			# Represents a `range` request header.
 			class Range
-				ParseError = Class.new(Error)
+				ParseError = Class.new(Error) do
+					include BadRequest
+				end
 				
 				TOKEN = /[!#$%&'*+\-.0-9A-Z^_`a-z|~]+/
 				HEADER = /\A(?<unit>#{TOKEN})=(?<ranges>.*)\z/

--- a/lib/protocol/http/header/server_timing.rb
+++ b/lib/protocol/http/header/server_timing.rb
@@ -23,7 +23,9 @@ module Protocol
 			# # => "db;dur=53.2, cache;dur=12.1;desc=\"Redis lookup\""
 			# ```
 			class ServerTiming < Split
-				ParseError = Class.new(Error)
+				ParseError = Class.new(Error) do
+					include BadRequest
+				end
 				
 				# https://www.w3.org/TR/server-timing/
 				METRIC = /\A(?<name>[a-zA-Z0-9][a-zA-Z0-9_\-]*)(;(?<parameters>.*))?\z/

--- a/lib/protocol/http/header/te.rb
+++ b/lib/protocol/http/header/te.rb
@@ -14,7 +14,9 @@ module Protocol
 			#
 			# The `te` header allows a client to indicate which transfer encodings it can handle, and in what order of preference using quality factors.
 			class TE < Split
-				ParseError = Class.new(Error)
+				ParseError = Class.new(Error) do
+					include BadRequest
+				end
 				
 				# Transfer encoding token pattern
 				TOKEN = /[!#$%&'*+\-.0-9A-Z^_`a-z|~]+/

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ Please see the [project releases](https://socketry.github.io/protocol-http/relea
 ### v0.67.0
 
   - Parse and resolve HTTP `Range` header values according to the default headers policy.
+  - Classify malformed header values as bad requests.
 
 ### v0.66.0
 

--- a/releases.md
+++ b/releases.md
@@ -3,6 +3,7 @@
 ## v0.67.0
 
   - Parse and resolve HTTP `Range` header values according to the default headers policy.
+  - Classify malformed header values as bad requests.
 
 ## v0.66.0
 

--- a/test/protocol/http/header/accept.rb
+++ b/test/protocol/http/header/accept.rb
@@ -20,6 +20,10 @@ describe Protocol::HTTP::Header::Accept::MediaRange do
 end
 
 describe Protocol::HTTP::Header::Accept do
+	it "classifies parse errors as bad requests" do
+		expect(subject::ParseError.new).to be_a(Protocol::HTTP::BadRequest)
+	end
+	
 	let(:header) {subject.parse(description)}
 	let(:media_ranges) {header.media_ranges.sort}
 	

--- a/test/protocol/http/header/accept_charset.rb
+++ b/test/protocol/http/header/accept_charset.rb
@@ -13,6 +13,10 @@ describe Protocol::HTTP::Header::AcceptCharset::Charset do
 end
 
 describe Protocol::HTTP::Header::AcceptCharset do
+	it "classifies parse errors as bad requests" do
+		expect(subject::ParseError.new).to be_a(Protocol::HTTP::BadRequest)
+	end
+	
 	let(:header) {subject.parse(description)}
 	let(:charsets) {header.charsets.sort}
 	

--- a/test/protocol/http/header/accept_encoding.rb
+++ b/test/protocol/http/header/accept_encoding.rb
@@ -13,6 +13,10 @@ describe Protocol::HTTP::Header::AcceptEncoding::Encoding do
 end
 
 describe Protocol::HTTP::Header::AcceptEncoding do
+	it "classifies parse errors as bad requests" do
+		expect(subject::ParseError.new).to be_a(Protocol::HTTP::BadRequest)
+	end
+	
 	let(:header) {subject.parse(description)}
 	let(:encodings) {header.encodings.sort}
 	

--- a/test/protocol/http/header/accept_language.rb
+++ b/test/protocol/http/header/accept_language.rb
@@ -13,6 +13,10 @@ describe Protocol::HTTP::Header::AcceptLanguage::Language do
 end
 
 describe Protocol::HTTP::Header::AcceptLanguage do
+	it "classifies parse errors as bad requests" do
+		expect(subject::ParseError.new).to be_a(Protocol::HTTP::BadRequest)
+	end
+	
 	let(:header) {subject.parse(description)}
 	let(:languages) {header.languages.sort}
 	

--- a/test/protocol/http/header/digest.rb
+++ b/test/protocol/http/header/digest.rb
@@ -7,6 +7,10 @@ require "protocol/http/header/digest"
 require "sus"
 
 describe Protocol::HTTP::Header::Digest do
+	it "classifies parse errors as bad requests" do
+		expect(subject::ParseError.new).to be_a(Protocol::HTTP::BadRequest)
+	end
+	
 	let(:header) {subject.parse(description)}
 	
 	with "empty header" do

--- a/test/protocol/http/header/range.rb
+++ b/test/protocol/http/header/range.rb
@@ -6,6 +6,10 @@
 require "protocol/http/header/range"
 
 describe Protocol::HTTP::Header::Range do
+	it "classifies parse errors as bad requests" do
+		expect(subject::ParseError.new).to be_a(Protocol::HTTP::BadRequest)
+	end
+	
 	with ".parse" do
 		it "parses byte ranges" do
 			header = subject.parse("bytes=0-4, 10-, -5")

--- a/test/protocol/http/header/server_timing.rb
+++ b/test/protocol/http/header/server_timing.rb
@@ -7,6 +7,10 @@ require "protocol/http/header/server_timing"
 require "sus"
 
 describe Protocol::HTTP::Header::ServerTiming do
+	it "classifies parse errors as bad requests" do
+		expect(subject::ParseError.new).to be_a(Protocol::HTTP::BadRequest)
+	end
+	
 	let(:header) {subject.parse(description)}
 	
 	with "empty header" do

--- a/test/protocol/http/header/te.rb
+++ b/test/protocol/http/header/te.rb
@@ -6,6 +6,10 @@
 require "protocol/http/header/te"
 
 describe Protocol::HTTP::Header::TE do
+	it "classifies parse errors as bad requests" do
+		expect(subject::ParseError.new).to be_a(Protocol::HTTP::BadRequest)
+	end
+	
 	let(:header) {subject.parse(description)}
 	
 	with "chunked" do


### PR DESCRIPTION
## Summary

- Mark parse errors from `Accept`, `Accept-Charset`, `Accept-Encoding`, `Accept-Language`, `Digest`, `Range`, `Server-Timing`, and `TE` as `Protocol::HTTP::BadRequest`.
- Give async-http a consistent response-capable error for malformed lazily parsed header values.
- Add explicit classification tests and an unreleased release note.

This PR is stacked on #112 so the `Range` parser remains independent of this classification decision.

## Tests

- `bundle exec bake test` (768 tests, 1,545 assertions, 100% coverage).
- `bundle exec bake decode:index:coverage lib` (438/438 definitions).
- Focused RuboCop passes.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the Developer Certificate of Origin 1.1.