### PR TITLE
Add HTTP status descriptions.

### DIFF
--- a/lib/protocol/http.rb
+++ b/lib/protocol/http.rb
@@ -5,6 +5,7 @@
 
 require_relative "http/version"
 
+require_relative "http/status"
 require_relative "http/headers"
 require_relative "http/request"
 require_relative "http/response"

--- a/lib/protocol/http/status.rb
+++ b/lib/protocol/http/status.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+module Protocol
+	module HTTP
+		# HTTP status codes and their human-readable descriptions.
+		module Status
+			# Human-readable descriptions for registered and conventional HTTP status codes.
+			DESCRIPTIONS = {
+				100 => "Continue",
+				101 => "Switching Protocols",
+				102 => "Processing",
+				103 => "Early Hints",
+				
+				200 => "OK",
+				201 => "Created",
+				202 => "Accepted",
+				203 => "Non-Authoritative Information",
+				204 => "No Content",
+				205 => "Reset Content",
+				206 => "Partial Content",
+				207 => "Multi-Status",
+				208 => "Already Reported",
+				226 => "IM Used",
+				
+				300 => "Multiple Choices",
+				301 => "Moved Permanently",
+				302 => "Found",
+				303 => "See Other",
+				304 => "Not Modified",
+				305 => "Use Proxy",
+				306 => "Switch Proxy",
+				307 => "Temporary Redirect",
+				308 => "Permanent Redirect",
+				
+				400 => "Bad Request",
+				401 => "Unauthorized",
+				402 => "Payment Required",
+				403 => "Forbidden",
+				404 => "Not Found",
+				405 => "Method Not Allowed",
+				406 => "Not Acceptable",
+				407 => "Proxy Authentication Required",
+				408 => "Request Timeout",
+				409 => "Conflict",
+				410 => "Gone",
+				411 => "Length Required",
+				412 => "Precondition Failed",
+				413 => "Content Too Large",
+				414 => "URI Too Long",
+				415 => "Unsupported Media Type",
+				416 => "Range Not Satisfiable",
+				417 => "Expectation Failed",
+				418 => "I'm a Teapot",
+				421 => "Misdirected Request",
+				422 => "Unprocessable Content",
+				423 => "Locked",
+				424 => "Failed Dependency",
+				425 => "Too Early",
+				426 => "Upgrade Required",
+				428 => "Precondition Required",
+				429 => "Too Many Requests",
+				431 => "Request Header Fields Too Large",
+				451 => "Unavailable For Legal Reasons",
+				
+				500 => "Internal Server Error",
+				501 => "Not Implemented",
+				502 => "Bad Gateway",
+				503 => "Service Unavailable",
+				504 => "Gateway Timeout",
+				505 => "HTTP Version Not Supported",
+				506 => "Variant Also Negotiates",
+				507 => "Insufficient Storage",
+				508 => "Loop Detected",
+				510 => "Not Extended",
+				511 => "Network Authentication Required",
+			}.freeze
+			
+			# Look up the human-readable description for a status code.
+			# @parameter code [Integer] The HTTP status code.
+			# @returns [String | Nil] The standard description, if known.
+			def self.description(code)
+				return DESCRIPTIONS[code]
+			end
+		end
+	end
+end

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Add HTTP status descriptions.
+
 ## v0.67.0
 
   - Parse and resolve HTTP `Range` header values according to the default headers policy.

--- a/test/protocol/http/status.rb
+++ b/test/protocol/http/status.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "protocol/http/status"
+
+describe Protocol::HTTP::Status do
+	it "provides status descriptions" do
+		expect(subject.description(100)).to be == "Continue"
+		expect(subject.description(200)).to be == "OK"
+		expect(subject.description(404)).to be == "Not Found"
+		expect(subject.description(500)).to be == "Internal Server Error"
+	end
+	
+	it "uses current descriptions" do
+		expect(subject.description(413)).to be == "Content Too Large"
+		expect(subject.description(422)).to be == "Unprocessable Content"
+	end
+	
+	it "returns nil for unknown status codes" do
+		expect(subject.description(599)).to be_nil
+	end
+end


### PR DESCRIPTION
## Summary

- add a canonical `Protocol::HTTP::Status::DESCRIPTIONS` mapping
- provide `Protocol::HTTP::Status.description` for status lookup
- expose status descriptions through `protocol/http`

## Testing

- `bundle exec bake test`
- `bundle exec bake decode:index:coverage lib`
- `bundle exec rubocop lib/protocol/http/status.rb test/protocol/http/status.rb`