### PR TITLE
Add stable Accept preference ordering.

### DIFF
--- a/lib/protocol/http/header/accept.rb
+++ b/lib/protocol/http/header/accept.rb
@@ -107,6 +107,17 @@ module Protocol
 					end
 				end
 				
+				# Parse the `accept` header and order media ranges by preference.
+				#
+				# Media ranges with equal quality factors retain their original relative order.
+				#
+				# @returns [Array(MediaRange)] the preferred media ranges.
+				def preferred_media_ranges
+					media_ranges.sort_by.with_index do |media_range, index|
+						[-media_range.quality_factor, index]
+					end
+				end
+				
 				private
 				
 				def parse_media_range(value)

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Add stable preference ordering for `Accept` media ranges.
+
 ## v0.69.0
 
   - Add `Protocol::HTTP::Body::Readable#to_io` for obtaining an IO-compatible stream adapter.

--- a/test/protocol/http/header/accept.rb
+++ b/test/protocol/http/header/accept.rb
@@ -21,7 +21,7 @@ end
 
 describe Protocol::HTTP::Header::Accept do
 	let(:header) {subject.parse(description)}
-	let(:media_ranges) {header.media_ranges.sort}
+	let(:media_ranges) {header.preferred_media_ranges}
 	
 	with "text/plain, text/html;q=0.5, text/xml;q=0.25" do
 		it "can parse media ranges" do
@@ -64,7 +64,7 @@ describe Protocol::HTTP::Header::Accept do
 	end
 	
 	with "text/html, text/plain;q=0.8, text/xml;q=0.6, application/json" do
-		it "should order based on quality factor" do
+		it "preserves relative order for equal quality factors" do
 			expect(media_ranges.collect(&:to_s)).to be == %w{text/html application/json text/plain;q=0.8 text/xml;q=0.6}
 		end
 	end


### PR DESCRIPTION
## Summary.

- Add `Accept#preferred_media_ranges` for ordering parsed media ranges by descending quality.
- Preserve source order when quality factors are equal.
- Keep `Accept#media_ranges` as the source-order parsing interface.

## Verification.

- `bundle exec sus test/protocol/http/header/accept.rb`: 21 tests, 61 assertions.
- `bundle exec sus`: 764 tests, 1551 assertions.
- RuboCop passes for the changed Ruby files.
- `git diff --check` passes.
